### PR TITLE
Handle empty NANO keep by falling back to full coin list

### DIFF
--- a/futures_gpt_orchestrator_full.py
+++ b/futures_gpt_orchestrator_full.py
@@ -83,8 +83,17 @@ def run(run_live: bool = False, limit: int = 20, ex=None) -> Dict[str, Any]:
     except Exception:
         keep = []
 
-    kept = [c for c in payload_full["coins"] if c["pair"] in keep] if keep else []
+    fallback_reason = None
+    kept: List[Dict[str, Any]] = []
+    if keep:
+        kept = [c for c in payload_full["coins"] if c["pair"] in keep]
+    elif payload_full["coins"]:
+        kept = payload_full["coins"]
+        fallback_reason = "keep_empty_used_all"
+
     payload_kept = {"time": payload_full["time"], "eth": payload_full["eth"], "coins": kept}
+    if fallback_reason:
+        payload_kept["fallback_reason"] = fallback_reason
     save_text(f"{stamp}_payload_kept.json", dumps_min(payload_kept))
 
     mini_text = ""
@@ -140,6 +149,8 @@ def run(run_live: bool = False, limit: int = 20, ex=None) -> Dict[str, Any]:
             )
 
     result = {"live": run_live, "capital": capital, "coins": coins, "placed": placed}
+    if fallback_reason:
+        result["fallback_reason"] = fallback_reason
     save_text(f"{stamp}_orders.json", dumps_min(result))
     return {"ts": stamp, **result}
 


### PR DESCRIPTION
## Summary
- Use all coins if NANO keep list is empty and coins are available
- Record fallback reason in payload and orders files for easier debugging

## Testing
- `python -m py_compile futures_gpt_orchestrator_full.py`


------
https://chatgpt.com/codex/tasks/task_e_68a7f13a06dc832385ae1fe0d57d8998