### PR TITLE
Skip actions without invalid side in enrich_tp_qty

### DIFF
--- a/trading_utils.py
+++ b/trading_utils.py
@@ -118,7 +118,8 @@ def enrich_tp_qty(exchange, acts: List[Dict[str, Any]], capital: float) -> List[
         a["qty"] = rfloat(qty, 8)
         a["risk"] = rfloat(rf, 6)
         side = infer_side(float(entry), float(sl), float(tp2))
-        a["side"] = side
-        out.append(a)
+        if side in {"buy", "sell"}:
+            a["side"] = side
+            out.append(a)
     return out
 


### PR DESCRIPTION
## Summary
- append actions only when inferred side is buy or sell in `enrich_tp_qty`

## Testing
- `python -m py_compile trading_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_68a7f14026988323a83d84d1debe3480