### PR TITLE
Use thread pool for concurrent data fetches

### DIFF
--- a/exchange_utils.py
+++ b/exchange_utils.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 from typing import Dict, List
 
+from concurrent.futures import ThreadPoolExecutor
 import ccxt
 import pandas as pd
 
@@ -12,6 +13,10 @@ from env_utils import rfloat
 
 # Symbols to skip when building the market universe
 BLACKLIST_BASES = {"BTC", "BNB"}
+
+# Shared thread pool for exchange requests with a conservative worker limit
+MAX_WORKERS = int(os.getenv("EX_MAX_WORKERS", "5"))
+THREAD_POOL = ThreadPoolExecutor(max_workers=MAX_WORKERS)
 
 
 def make_exchange() -> ccxt.Exchange:

--- a/exchange_utils.py
+++ b/exchange_utils.py
@@ -6,6 +6,7 @@ import os
 from typing import Dict, List
 
 from concurrent.futures import ThreadPoolExecutor
+import atexit
 import ccxt
 import pandas as pd
 
@@ -17,6 +18,7 @@ BLACKLIST_BASES = {"BTC", "BNB"}
 # Shared thread pool for exchange requests with a conservative worker limit
 MAX_WORKERS = int(os.getenv("EX_MAX_WORKERS", "5"))
 THREAD_POOL = ThreadPoolExecutor(max_workers=MAX_WORKERS)
+atexit.register(THREAD_POOL.shutdown, wait=False)
 
 
 def make_exchange() -> ccxt.Exchange:

--- a/exchange_utils.py
+++ b/exchange_utils.py
@@ -15,7 +15,7 @@ from env_utils import rfloat
 # Symbols to skip when building the market universe
 BLACKLIST_BASES = {"BTC", "BNB"}
 
-# Shared thread pool for exchange requests with a conservative worker limit
+# Shared thread pool for exchange requests limited by EX_MAX_WORKERS
 MAX_WORKERS = int(os.getenv("EX_MAX_WORKERS", "5"))
 THREAD_POOL = ThreadPoolExecutor(max_workers=MAX_WORKERS)
 atexit.register(THREAD_POOL.shutdown, wait=False)

--- a/payload_builder.py
+++ b/payload_builder.py
@@ -48,7 +48,7 @@ _H4_LOCK = Lock()
 
 
 def _schedule_cached_df(
-    tasks: Dict[str, any],
+    tasks: Dict[str, Any],
     key: str,
     exchange,
     symbol: str,


### PR DESCRIPTION
## Summary
- Add global `THREAD_POOL` with limited workers for exchange calls
- Fetch OHLCV and orderbook data concurrently while guarding H1/H4 caches

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a7f1cb20748323be0a042463b827f9