### PR TITLE
Ignore cache and virtual environment folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .env
+__pycache__/
+.venv/


### PR DESCRIPTION
## Summary
- keep Python cache directories and local virtual environments out of version control by updating `.gitignore`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a82cdec944832385fa5766e3788da1