### PR TITLE
Improve cache refresh and resilience

### DIFF
--- a/openai_client.py
+++ b/openai_client.py
@@ -4,17 +4,26 @@ from __future__ import annotations
 
 import os
 import re
+import time
 from typing import Any, Dict, Optional
 
-from openai import OpenAI
+from openai import (
+    APIConnectionError,
+    APITimeoutError,
+    OpenAI,
+)
 
-import time
+
+API_KEY = os.getenv("OPENAI_API_KEY")
+if not API_KEY:
+    raise RuntimeError("OPENAI_API_KEY is not set")
+
+CLIENT = OpenAI(api_key=API_KEY)
 
 
 def send_openai(system_text: str, user_text: str, model: str) -> Dict[str, Any]:
     """Gửi yêu cầu chat completion với cơ chế retry đơn giản."""
 
-    client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
     body = {
         "model": model,
         "messages": [
@@ -25,11 +34,19 @@ def send_openai(system_text: str, user_text: str, model: str) -> Dict[str, Any]:
     }
     for attempt in range(3):  # thử tối đa 3 lần
         try:
-            resp = client.chat.completions.create(**body)
+            resp = CLIENT.chat.completions.create(**body)
             try:
                 return resp.to_dict()  # trả về dict nếu có thể
             except Exception:
                 return resp  # fallback nguyên bản
+        except (APIConnectionError, APITimeoutError) as e:
+            if attempt < 2:
+                wait = 2 * (attempt + 1)
+                print(f"send_openai lỗi kết nối {e}, đợi {wait}s rồi thử lại")
+                time.sleep(wait)
+                continue
+            print(f"send_openai lỗi kết nối: {e}")
+            raise
         except Exception as e:
             code = getattr(e, "status", None) or getattr(e, "http_status", None)
             if attempt < 2 and (code is None or code >= 500 or code == 429):

--- a/tests/test_trading_utils.py
+++ b/tests/test_trading_utils.py
@@ -1,0 +1,17 @@
+import types
+import pathlib
+import sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+import trading_utils
+
+
+def test_to_ccxt_symbol_known_quotes():
+    assert trading_utils.to_ccxt_symbol("BTCUSDT") == "BTC/USDT"
+    assert trading_utils.to_ccxt_symbol("ETHBTC") == "ETH/BTC"
+    assert trading_utils.to_ccxt_symbol("LTCBUSD") == "LTC/BUSD"
+
+
+def test_to_ccxt_symbol_with_exchange_markets():
+    dummy = types.SimpleNamespace(markets={"FOO/USDC": {"symbol": "FOO/USDC"}})
+    assert trading_utils.to_ccxt_symbol("FOOUSDC", dummy) == "FOO/USDC"


### PR DESCRIPTION
## Summary
- refresh H1/H4 OHLCV caches incrementally
- isolate failing coins when building payloads
- support variable quote currencies in `to_ccxt_symbol`
- reuse OpenAI client and validate API key
- safer orchestrator restarts via PID file

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=. OPENAI_API_KEY=dummy pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a83cb5a41883238535f45bf739315a