### PR TITLE
Add support/resistance level detection

### DIFF
--- a/payload_builder.py
+++ b/payload_builder.py
@@ -14,7 +14,7 @@ from threading import Lock
 
 from env_utils import compact, drop_empty, now_ms, rfloat
 from exchange_utils import fetch_ohlcv_df, orderbook_snapshot, top_by_qv
-from indicators import add_indicators, trend_lbl
+from indicators import add_indicators, trend_lbl, detect_sr_levels
 
 logger = logging.getLogger(__name__)
 
@@ -82,6 +82,7 @@ def build_1h(df: pd.DataFrame) -> Dict:
         "swing_high": swing_high,
         "swing_low": swing_low,
     }
+    sr_levels = [rfloat(lvl) for lvl in detect_sr_levels(data, lookback=5)]
     ind = {
         "ema20": compact(data["ema20"].tail(20).tolist()),
         "ema50": compact(data["ema50"].tail(20).tolist()),
@@ -94,7 +95,7 @@ def build_1h(df: pd.DataFrame) -> Dict:
         "atr14": compact(data["atr14"].tail(20).tolist()),
         "vol_spike": compact(data["vol_spike"].tail(20).tolist()),
     }
-    return {"ohlcv": ohlcv20, "ind": ind, "key": key}
+    return {"ohlcv": ohlcv20, "ind": ind, "key": key, "sr_levels": sr_levels}
 
 
 def build_snap(df: pd.DataFrame) -> Dict:

--- a/prompts.py
+++ b/prompts.py
@@ -8,8 +8,8 @@ PROMPT_SYS_MINI = (
     'No prose. No markdown. If none, return {"coins":[]}.'
 )
 PROMPT_USER_MINI = (
-    'Phân tích 1h (20 ohlcv+chỉ báo), H4/D1 snapshot, ETH bias, session, orderbook. '
-    'Dùng price action, cấu trúc HH/HL/LH/LL, breakout, divergence, momentum/vol_spike, key level, MTF. '
+    'Phân tích 1h (20 ohlcv+chỉ báo+sr_levels), H4/D1 snapshot, ETH bias, session, orderbook. '
+    'Dùng price action, cấu trúc HH/HL/LH/LL, breakout, divergence, momentum/vol_spike, sr_levels, key level, MTF. '
     'Output JSON: {"coins":[{"pair":"SYMBOL","entry":0.0,"sl":0.0,"tp2":0.0,"risk":0.0},...]}. '
     'Ưu tiên RR>=1.8; cho phép <1.8 khi PA+volume cực mạnh & đồng thuận đa khung. H4/D1 cùng hướng 1h; ETH cùng hướng thêm điểm; '
     'cho phép ngược pha khi có đảo chiều rõ + vol_spike. Session: Asia siết/US nới/EU tb; mins_to_close<=15 & yếu → bỏ. '


### PR DESCRIPTION
## Summary
- implement `detect_sr_levels` to identify support/resistance zones
- include `sr_levels` in 1h payloads and reference them in prompts

## Testing
- `OPENAI_API_KEY=dummy pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a93d56b3688323b81f79e00a11b2b4