### PR TITLE
Include funding data and tune orderbook for 1h

### DIFF
--- a/payload_builder.py
+++ b/payload_builder.py
@@ -13,7 +13,12 @@ import pandas as pd
 from threading import Lock
 
 from env_utils import compact, drop_empty, now_ms, rfloat
-from exchange_utils import fetch_ohlcv_df, orderbook_snapshot, top_by_qv
+from exchange_utils import (
+    fetch_ohlcv_df,
+    orderbook_snapshot,
+    top_by_qv,
+    funding_rate,
+)
 from indicators import add_indicators, trend_lbl
 
 logger = logging.getLogger(__name__)
@@ -156,7 +161,8 @@ def coin_payload(exchange, symbol: str) -> Dict:
         "h1": build_1h(h1),
         "h4": build_snap(h4),
         "d1": build_snap(d1),
-        "orderbook": orderbook_snapshot(exchange, symbol, depth=10),
+        "orderbook": orderbook_snapshot(exchange, symbol),
+        "funding": funding_rate(exchange, symbol),
     }
     return drop_empty(payload)
 

--- a/prompts.py
+++ b/prompts.py
@@ -8,7 +8,7 @@ PROMPT_SYS_MINI = (
     'No prose. No markdown. If none, return {"coins":[]}.'
 )
 PROMPT_USER_MINI = (
-    'Phân tích 1h (20 ohlcv+chỉ báo), H4/D1 snapshot, ETH bias, session, orderbook. '
+    'Phân tích 1h (20 ohlcv+chỉ báo), H4/D1 snapshot, ETH bias, session, orderbook, funding. '
     'Dùng price action, cấu trúc HH/HL/LH/LL, breakout, divergence, momentum/vol_spike, key level, MTF. '
     'Output JSON: {"coins":[{"pair":"SYMBOL","entry":0.0,"sl":0.0,"tp2":0.0,"risk":0.0},...]}. '
     'Ưu tiên RR>=1.8; cho phép <1.8 khi PA+volume cực mạnh & đồng thuận đa khung. H4/D1 cùng hướng 1h; ETH cùng hướng thêm điểm; '

--- a/tests/test_exchange_utils.py
+++ b/tests/test_exchange_utils.py
@@ -1,0 +1,18 @@
+import types
+import pathlib
+import sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from exchange_utils import funding_rate
+
+
+def test_funding_rate_returns_fields():
+    def _fetch(symbol):
+        return {"fundingRate": "0.0005", "nextFundingTime": 1234567890}
+
+    dummy = types.SimpleNamespace(fetch_funding_rate=_fetch)
+    snap = funding_rate(dummy, "FOO/USDT")
+    assert snap["rate"] == 0.0005
+    assert snap["next_funding"] == 1234567890
+

--- a/tests/test_trading_utils.py
+++ b/tests/test_trading_utils.py
@@ -1,8 +1,14 @@
 import types
 import pathlib
 import sys
+import os
 
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+# ``trading_utils`` indirectly requires an OpenAI API key during import.
+# Tests supply a dummy value so the import does not fail.
+os.environ.setdefault("OPENAI_API_KEY", "test")
+
 import trading_utils
 
 


### PR DESCRIPTION
## Summary
- expand order book snapshot to 20 levels to better suit the 1h timeframe
- expose current funding rate and next funding time in payloads and prompts
- cover funding rate helper with unit tests and fix test imports

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a93cbf71a08323867a79febbc69e13