### PR TITLE
Expand hourly payload with market metrics and news

### DIFF
--- a/prompts.py
+++ b/prompts.py
@@ -8,7 +8,8 @@ PROMPT_SYS_MINI = (
     'No prose. No markdown. If none, return {"coins":[]}.'
 )
 PROMPT_USER_MINI = (
-    'Phân tích 1h (20 ohlcv+chỉ báo+sr_levels), H4/D1 snapshot, ETH bias, session, orderbook. '
+    'Phân tích 1h (20 ohlcv+chỉ báo+sr_levels), H4/D1 snapshot, ETH bias, session, funding/OI/CVD/liquidation, '
+    'news vĩ mô, crypto news/unlock, orderbook. '
     'Dùng price action, cấu trúc HH/HL/LH/LL, breakout, divergence, momentum/vol_spike, sr_levels, key level, MTF. '
     'Output JSON: {"coins":[{"pair":"SYMBOL","entry":0.0,"sl":0.0,"tp2":0.0,"risk":0.0},...]}. '
     'Ưu tiên RR>=1.8; cho phép <1.8 khi PA+volume cực mạnh & đồng thuận đa khung. H4/D1 cùng hướng 1h; ETH cùng hướng thêm điểm; '


### PR DESCRIPTION
## Summary
- add open interest, CVD, and liquidation snapshots for each coin
- include OI/CVD/liquidation metrics and macro/crypto news in the hourly payload
- update mini model prompt to reference new data points

## Testing
- `pytest -q` *(fails: OPENAI_API_KEY is not set)*
- `OPENAI_API_KEY=dummy pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a94261cd7c83238f15e03ff2cdf4cd