### PR TITLE
Use HTTP news API in payload builder

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ numpy>=1.26.0
 openai>=1.40.0
 pandas-ta>=0.3.14b
 python-dotenv>=1.0.1
+requests>=2.31.0

--- a/tests/test_payload_builder.py
+++ b/tests/test_payload_builder.py
@@ -1,0 +1,37 @@
+import pathlib
+import sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+import payload_builder  # noqa: E402
+import requests  # noqa: E402
+
+
+class DummyResponse:
+    def __init__(self, data):
+        self._data = data
+
+    def json(self):
+        return self._data
+
+    def raise_for_status(self):
+        pass
+
+
+def test_news_snapshot(monkeypatch):
+    def fake_get(url, params=None, timeout=None):
+        assert "auth_token" in params
+        data = {
+            "macro": "m" * 300,
+            "crypto": "c" * 10,
+            "unlock": "u",
+        }
+        return DummyResponse(data)
+
+    monkeypatch.setenv("NEWS_API_KEY", "key")
+    monkeypatch.setattr(requests, "get", fake_get)
+    snap = payload_builder.news_snapshot()
+    assert snap == {
+        "macro": "m" * payload_builder.MAX_NEWS_LEN,
+        "crypto": "c" * 10,
+        "unlock": "u",
+    }


### PR DESCRIPTION
## Summary
- Replace environment-variable based news snapshot with request to remote API
- Add `requests` dependency
- Cover news snapshot with unit test
- Truncate news fields to limit tokens passed downstream

## Testing
- `OPENAI_API_KEY=dummy pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a9457d1d34832387e3682b20c51b1e