### PR TITLE
Skip GPT when positions are open

### DIFF
--- a/futures_gpt_orchestrator_full.py
+++ b/futures_gpt_orchestrator_full.py
@@ -96,6 +96,22 @@ def run(run_live: bool = False, limit: int = 20, ex=None) -> Dict[str, Any]:
         capital = 0.0
 
     pos_pairs = get_open_position_pairs(ex)
+    if pos_pairs:
+        stamp = ts_prefix()
+        save_text(
+            f"{stamp}_orders.json",
+            dumps_min(
+                {
+                    "live": run_live,
+                    "capital": capital,
+                    "coins": [],
+                    "placed": [],
+                    "reason": "existing_positions",
+                }
+            ),
+        )
+        return {"ts": stamp, "capital": capital, "coins": [], "placed": []}
+
     payload_full = build_payload(ex, limit, exclude_pairs=pos_pairs)
     stamp = ts_prefix()
     save_text(f"{stamp}_payload_full.json", dumps_min(payload_full))

--- a/tests/test_futures_gpt_orchestrator_full.py
+++ b/tests/test_futures_gpt_orchestrator_full.py
@@ -1,0 +1,39 @@
+import json
+import os
+import pathlib
+import sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+os.environ.setdefault("OPENAI_API_KEY", "test")
+import futures_gpt_orchestrator_full as orch  # noqa: E402
+
+
+class DummyExchange:
+    def fetch_balance(self):
+        return {"total": {"USDT": 1000}}
+
+
+def test_run_skips_gpt_when_positions(monkeypatch):
+    monkeypatch.setattr(orch, "load_env", lambda: None)
+    monkeypatch.setattr(orch, "get_models", lambda: (None, "MODEL"))
+    monkeypatch.setattr(orch, "ts_prefix", lambda: "ts")
+
+    def fake_save_text(path, text):
+        fake_save_text.saved[path] = text
+
+    fake_save_text.saved = {}
+    monkeypatch.setattr(orch, "save_text", fake_save_text)
+    monkeypatch.setattr(orch, "get_open_position_pairs", lambda ex: {"ETHUSDT"})
+
+    def boom(*args, **kwargs):  # should never be called
+        raise AssertionError("should not be called")
+
+    monkeypatch.setattr(orch, "build_payload", boom)
+    monkeypatch.setattr(orch, "send_openai", boom)
+
+    res = orch.run(run_live=False, ex=DummyExchange())
+
+    assert res == {"ts": "ts", "capital": 1000.0, "coins": [], "placed": []}
+    assert "ts_orders.json" in fake_save_text.saved
+    data = json.loads(fake_save_text.saved["ts_orders.json"])
+    assert data["reason"] == "existing_positions"

--- a/tests/test_trading_utils.py
+++ b/tests/test_trading_utils.py
@@ -1,8 +1,10 @@
 import types
 import pathlib
 import sys
+import os
 
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+os.environ.setdefault("OPENAI_API_KEY", "test")
 import trading_utils
 
 


### PR DESCRIPTION
## Summary
- Skip GPT payload generation when open positions already exist, writing an `existing_positions` reason to the orders log and returning early.
- Add regression test to ensure GPT is bypassed when open positions are detected.
- Set a default `OPENAI_API_KEY` in tests to avoid import errors.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a9588a1ba4832381e2579757b245cc