### PR TITLE
feat: update default risk to 1%

### DIFF
--- a/prompts.py
+++ b/prompts.py
@@ -13,7 +13,7 @@ PROMPT_USER_MINI = (
     "Dữ liệu đầy đủ dưới đây (không bỏ sót bất kỳ trường nào). "
     "Phân tích toàn bộ như 1 trader chuyên nghiệp, kết hợp price action, đa khung (1H/H4/D1), ETH bias, "
     "orderbook, funding/OI/CVD/liquidation, news. "
-    "Trả về JSON duy nhất dạng {\"coins\":[{\"pair\":\"SYMBOL\",\"entry\":0.0,\"sl\":0.0,\"tp2\":0.0,\"risk\":0.0}, ...]}. "
+    "Trả về JSON duy nhất dạng {\"coins\":[{\"pair\":\"SYMBOL\",\"entry\":0.0,\"sl\":0.0,\"tp2\":0.0}, ...]}. "
     "Không có tín hiệu → {\"coins\":[]}. "
     "DATA:{payload}"
 )

--- a/trading_utils.py
+++ b/trading_utils.py
@@ -157,7 +157,7 @@ def enrich_tp_qty(exchange, acts: List[Dict[str, Any]], capital: float) -> List[
         if not (isinstance(tp2, (int, float)) and tp2 > 0 and tp2 != entry):
             tp2 = entry + 2 * (entry - sl) if entry > sl else entry - 2 * (sl - entry)
         a["tp2"] = rfloat(tp2, 8)
-        rf = float(risk) if isinstance(risk, (int, float)) and risk > 0 else 0.005
+        rf = float(risk) if isinstance(risk, (int, float)) and risk > 0 else 0.01
         ccxt_sym = to_ccxt_symbol(a["pair"])
         step = qty_step(exchange, ccxt_sym)
         m = exchange.market(ccxt_sym)  # lấy thông tin thị trường


### PR DESCRIPTION
## Summary
- raise default risk per trade to 1%
- simplify trading prompt to omit risk requirement

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a95f919034832388730293c4c533ef