### PR TITLE
Handle open futures positions in orchestrator

### DIFF
--- a/tests/test_futures_gpt_orchestrator_full.py
+++ b/tests/test_futures_gpt_orchestrator_full.py
@@ -13,7 +13,7 @@ class DummyExchange:
         return {"total": {"USDT": 1000}}
 
 
-def test_run_skips_gpt_when_positions(monkeypatch):
+def test_run_excludes_positions_from_gpt(monkeypatch):
     monkeypatch.setattr(orch, "load_env", lambda: None)
     monkeypatch.setattr(orch, "get_models", lambda: (None, "MODEL"))
     monkeypatch.setattr(orch, "ts_prefix", lambda: "ts")
@@ -25,15 +25,44 @@ def test_run_skips_gpt_when_positions(monkeypatch):
     monkeypatch.setattr(orch, "save_text", fake_save_text)
     monkeypatch.setattr(orch, "get_open_position_pairs", lambda ex: {"ETHUSDT"})
 
-    def boom(*args, **kwargs):  # should never be called
-        raise AssertionError("should not be called")
+    build_called = {}
 
-    monkeypatch.setattr(orch, "build_payload", boom)
-    monkeypatch.setattr(orch, "send_openai", boom)
+    def fake_build_payload(ex, limit):
+        build_called["called"] = True
+        return {
+            "time": {},
+            "eth": {},
+            "news": {},
+            "coins": [{"pair": "ETHUSDT"}, {"pair": "BTCUSDT"}],
+        }
+
+    monkeypatch.setattr(orch, "build_payload", fake_build_payload)
+
+    captured = {}
+
+    def fake_send_openai(system, user, model):
+        captured["user"] = user
+        return {"choices": [{"message": {"content": "{\"coins\": []}"}}]}
+
+    monkeypatch.setattr(orch, "send_openai", fake_send_openai)
+    monkeypatch.setattr(
+        orch, "extract_content", lambda r: r["choices"][0]["message"]["content"]
+    )
+    monkeypatch.setattr(orch, "parse_mini_actions", lambda text: [])
+    monkeypatch.setattr(orch, "enrich_tp_qty", lambda ex, coins, capital: coins)
 
     res = orch.run(run_live=False, ex=DummyExchange())
 
-    assert res == {"ts": "ts", "capital": 1000.0, "coins": [], "placed": []}
+    assert build_called.get("called")
+    assert "ETHUSDT" not in captured.get("user", "")
+    assert res == {
+        "ts": "ts",
+        "live": False,
+        "capital": 1000.0,
+        "coins": [],
+        "placed": [],
+    }
     assert "ts_orders.json" in fake_save_text.saved
     data = json.loads(fake_save_text.saved["ts_orders.json"])
-    assert data["reason"] == "existing_positions"
+    assert "reason" not in data
+    assert data["coins"] == []


### PR DESCRIPTION
## Summary
- Continue orchestrator run even when there are open positions, only removing those pairs from the GPT payload
- Filter GPT actions against existing positions
- Add regression test ensuring open positions are excluded from GPT data

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a967a2b4048323b7b4b41cc3a9acf7