### PR TITLE
feat: update news snapshot

### DIFF
--- a/tests/test_payload_builder.py
+++ b/tests/test_payload_builder.py
@@ -18,20 +18,18 @@ class DummyResponse:
 
 
 def test_news_snapshot(monkeypatch):
-    def fake_get(url, params=None, timeout=None):
+    def fake_get(url, params=None, timeout=None, headers=None):
         assert "auth_token" in params
         data = {
-            "macro": "m" * 300,
-            "crypto": "c" * 10,
-            "unlock": "u",
+            "results": [
+                {"title": "A", "domain": "d1"},
+                {"title": "B" * 130, "domain": "d2"},
+            ]
         }
         return DummyResponse(data)
 
     monkeypatch.setenv("NEWS_API_KEY", "key")
     monkeypatch.setattr(requests, "get", fake_get)
     snap = payload_builder.news_snapshot()
-    assert snap == {
-        "macro": "m" * payload_builder.MAX_NEWS_LEN,
-        "crypto": "c" * 10,
-        "unlock": "u",
-    }
+    long_headline = "B" * 120 + "…"
+    assert snap == {"news": f"A – d1 • {long_headline}"}


### PR DESCRIPTION
## Summary
- simplify string truncation helper with ellipsis support
- fetch top CryptoPanic headlines and compact into single news field
- adjust tests for new news snapshot behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a9689afca48323a42a6720036dae84