### PR TITLE
Add close action examples to mini prompt

### DIFF
--- a/prompts.py
+++ b/prompts.py
@@ -13,8 +13,11 @@ PROMPT_USER_MINI = (
     "Dữ liệu đầy đủ dưới đây (không bỏ sót bất kỳ trường nào). "
     "Phân tích toàn bộ như 1 trader chuyên nghiệp, kết hợp price action, đa khung (1H/H4/D1), ETH bias, "
     "orderbook, funding/OI/CVD/liquidation, news. "
-    "Trả về JSON duy nhất dạng {\"coins\":[{\"pair\":\"SYMBOL\",\"entry\":0.0,\"sl\":0.0,\"tp2\":0.0}, ...]}. "
-    "Không có tín hiệu → {\"coins\":[]}. "
+    "Nếu phát hiện nguy cơ đảo chiều thì có thể đóng vị thế bằng hành động \"close_all\" hoặc \"close_partial\". "
+    "Trả về JSON duy nhất dạng {\"coins\":[{\"pair\":\"SYMBOL\",\"entry\":0.0,\"sl\":0.0,\"tp2\":0.0}],"
+    "\"close_all\":[{\"pair\":\"SYMBOL\"}],"
+    "\"close_partial\":[{\"pair\":\"SYMBOL\",\"pct\":50}]}. "
+    "Không có tín hiệu → {\"coins\":[],\"close_all\":[],\"close_partial\":[]}. "
     "Chỉ chọn LIMIT entry tối ưu (best limit entry). "
     "DATA:{payload}"
 )

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -1,0 +1,16 @@
+import pathlib
+import sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+from prompts import build_prompts_mini  # noqa: E402
+from env_utils import dumps_min  # noqa: E402
+
+
+def test_build_prompts_mini_injects_payload():
+    payload = {"a": 1}
+    pr = build_prompts_mini(payload)
+    dumped = dumps_min(payload)
+    assert dumped in pr["user"]
+    assert pr["user"].count(dumped) == 1
+    assert "{payload}" not in pr["user"]
+


### PR DESCRIPTION
## Summary
- clarify mini prompt so GPT can output `close_all` and `close_partial` actions when reversals loom
- show expected JSON for closing directives
- test `build_prompts_mini` to ensure payload injection works

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a9cda869c883239d28b62815240b7f