### PR TITLE
Handle close actions from GPT

### DIFF
--- a/payload_builder.py
+++ b/payload_builder.py
@@ -26,6 +26,7 @@ from exchange_utils import (
     top_by_qv,
 )
 from indicators import add_indicators, trend_lbl, detect_sr_levels
+from positions import positions_snapshot
 
 logger = logging.getLogger(__name__)
 
@@ -275,5 +276,6 @@ def build_payload(exchange, limit: int = 20, exclude_pairs: Set[str] | None = No
         "eth": eth_bias(exchange),
         "news": news_snapshot(),
         "coins": [drop_empty(c) for c in coins],
+        "positions": positions_snapshot(exchange),
     }
 

--- a/positions.py
+++ b/positions.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-from typing import Set
+from typing import Dict, List, Set
+
+from env_utils import drop_empty, rfloat
 
 
 def _norm_pair_from_symbol(symbol: str) -> str:
@@ -35,5 +37,71 @@ def get_open_position_pairs(exchange) -> Set[str]:
                 continue
     except Exception:
         pass
+    return out
+
+
+def positions_snapshot(exchange) -> List[Dict]:
+    """Return snapshot of open positions with entry, SL and TP."""
+
+    out: List[Dict] = []
+    try:
+        positions = exchange.fetch_positions()
+    except Exception:
+        return out
+
+    for p in positions or []:
+        sym = p.get("symbol") or (p.get("info") or {}).get("symbol")
+        pair = _norm_pair_from_symbol(sym)
+        amt = p.get("contracts")
+        if amt is None:
+            amt = p.get("amount")
+        if amt is None:
+            amt = (p.get("info") or {}).get("positionAmt")
+        entry = p.get("entryPrice") or (p.get("info") or {}).get("entryPrice")
+        try:
+            amt_val = float(amt)
+            entry_price = float(entry)
+        except Exception:
+            continue
+        if amt_val == 0:
+            continue
+        side = "buy" if amt_val > 0 else "sell"
+        sl = None
+        tp1 = None
+        tp2 = None
+        try:
+            orders = exchange.fetch_open_orders(sym)
+        except Exception:
+            orders = []
+        sl_orders = [
+            o
+            for o in orders
+            if (o.get("type") or "").lower() == "stop" and o.get("reduceOnly")
+        ]
+        tp_orders = [
+            o
+            for o in orders
+            if (o.get("type") or "").lower() == "limit" and o.get("reduceOnly")
+        ]
+        if sl_orders:
+            sl = rfloat(sl_orders[0].get("stopPrice") or sl_orders[0].get("price"))
+        prices = [float(o.get("price") or 0) for o in tp_orders]
+        prices.sort(reverse=(side == "sell"))
+        if len(prices) >= 1:
+            tp1 = rfloat(prices[0])
+        if len(prices) >= 2:
+            tp2 = rfloat(prices[1])
+        out.append(
+            drop_empty(
+                {
+                    "pair": pair,
+                    "side": side,
+                    "entry": rfloat(entry_price),
+                    "sl": sl,
+                    "tp1": tp1,
+                    "tp2": tp2,
+                }
+            )
+        )
     return out
 

--- a/tests/test_trading_utils.py
+++ b/tests/test_trading_utils.py
@@ -17,3 +17,16 @@ def test_to_ccxt_symbol_known_quotes():
 def test_to_ccxt_symbol_with_exchange_markets():
     dummy = types.SimpleNamespace(markets={"FOO/USDC": {"symbol": "FOO/USDC"}})
     assert trading_utils.to_ccxt_symbol("FOOUSDC", dummy) == "FOO/USDC"
+
+
+def test_parse_mini_actions_handles_close():
+    text = (
+        "{"
+        '"coins":[{"pair":"BTCUSDT","entry":1,"sl":0.9,"tp2":1.1}],'
+        '"close_all":[{"pair":"ETHUSDT"}],'
+        '"close_partial":[{"pair":"LTCUSDT","pct":25}]}'
+    )
+    res = trading_utils.parse_mini_actions(text)
+    assert res["coins"] and res["coins"][0]["pair"] == "BTCUSDT"
+    assert res["close_all"] == [{"pair": "ETHUSDT"}]
+    assert res["close_partial"] == [{"pair": "LTCUSDT", "pct": 25.0}]


### PR DESCRIPTION
## Summary
- Parse `close_all` and `close_partial` directives from GPT responses
- Execute reduce-only market exits for close signals in orchestrator
- Extend test coverage for new parsing and payload fields

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a9ce787f44832380c5aab3a928f9ff