### PR TITLE
Add 24h change fallback to meet coin limit

### DIFF
--- a/exchange_utils.py
+++ b/exchange_utils.py
@@ -61,6 +61,23 @@ def top_by_qv(exchange: ccxt.Exchange, limit: int = 20) -> List[str]:
         return symbols[:limit]
 
 
+def top_by_24h_change(exchange: ccxt.Exchange, limit: int = 20) -> List[str]:
+    """Return ``limit`` symbols sorted by absolute 24h percentage change."""
+
+    markets = load_usdtm(exchange)
+    symbols = list(markets.keys())
+    try:
+        tickers = exchange.fetch_tickers()
+        scored = []
+        for sym in symbols:
+            pct = (tickers.get(sym) or {}).get("percentage") or 0
+            scored.append((sym, abs(float(pct))))
+        scored.sort(key=lambda x: x[1], reverse=True)
+        return [s for s, _ in scored[:limit]]
+    except Exception:
+        return symbols[:limit]
+
+
 def fetch_ohlcv_df(exchange: ccxt.Exchange, symbol: str, timeframe: str, limit: int) -> pd.DataFrame:
     """Fetch OHLCV data and return as a tidy :class:`~pandas.DataFrame`."""
 

--- a/payload_builder.py
+++ b/payload_builder.py
@@ -9,7 +9,13 @@ import pandas as pd
 from threading import Lock
 
 from env_utils import compact, drop_empty, now_ms, rfloat
-from exchange_utils import fetch_ohlcv_df, orderbook_snapshot, top_by_qv
+from exchange_utils import (
+    fetch_ohlcv_df,
+    orderbook_snapshot,
+    top_by_qv,
+    top_by_24h_change,
+    load_usdtm,
+)
 from indicators import add_indicators, trend_lbl
 
 
@@ -169,6 +175,24 @@ def build_payload(exchange, limit: int = 20, exclude_pairs: Set[str] | None = No
         symbols.append(s)
         if len(symbols) >= limit:
             break
+    if len(symbols) < limit:
+        fallback_raw = top_by_24h_change(exchange, limit * 3)
+        for s in fallback_raw:
+            pair = s.replace("/", "").upper()
+            if pair in exclude_pairs or s in symbols:
+                continue
+            symbols.append(s)
+            if len(symbols) >= limit:
+                break
+    if len(symbols) < limit:
+        all_markets = load_usdtm(exchange)
+        for s in all_markets:
+            pair = s.replace("/", "").upper()
+            if pair in exclude_pairs or s in symbols:
+                continue
+            symbols.append(s)
+            if len(symbols) >= limit:
+                break
     coins = [coin_payload(exchange, s) for s in symbols]
     return {
         "time": {"now_utc": now_ms(), "session": session_meta()},


### PR DESCRIPTION
## Summary
- add `top_by_24h_change` helper to fetch markets sorted by 24h percentage change
- extend payload building to use 24h change list when quote-volume list lacks symbols
- ensure payload always fills to the requested limit by drawing from the full market list as a final fallback

## Testing
- `python -m py_compile exchange_utils.py payload_builder.py`


------
https://chatgpt.com/codex/tasks/task_e_68a9dd798c348323adc0e140f850e0a3