### PR TITLE
Exclude stablecoins from futures market universe

### DIFF
--- a/exchange_utils.py
+++ b/exchange_utils.py
@@ -11,8 +11,21 @@ import requests
 
 from env_utils import rfloat
 
+# Stablecoins that should not be traded
+STABLE_BASES = {
+    "USDT",
+    "USDC",
+    "BUSD",
+    "TUSD",
+    "FDUSD",
+    "USDP",
+    "SUSD",
+    "USTC",
+    "DAI",
+}
+
 # Symbols to skip when building the market universe
-BLACKLIST_BASES = {"BTC", "BNB"}
+BLACKLIST_BASES = {"BTC", "BNB"} | STABLE_BASES
 
 
 def make_exchange() -> ccxt.Exchange:
@@ -28,7 +41,7 @@ def make_exchange() -> ccxt.Exchange:
 
 
 def load_usdtm(exchange: ccxt.Exchange) -> Dict[str, Dict]:
-    """Return all active USDT-margined futures markets except blacklisted bases."""
+    """Return all active USDT-margined futures markets excluding stablecoins and other blacklisted bases."""
 
     markets = exchange.load_markets()
     out: Dict[str, Dict] = {}

--- a/tests/test_exchange_utils.py
+++ b/tests/test_exchange_utils.py
@@ -17,6 +17,34 @@ class DummyResponse:
         pass
 
 
+def test_load_usdtm_filters_stablecoins():
+    class DummyExchange:
+        def load_markets(self):
+            return {
+                "ETH/USDT:USDT": {
+                    "symbol": "ETH/USDT:USDT",
+                    "linear": True,
+                    "swap": True,
+                    "quote": "USDT",
+                    "active": True,
+                    "base": "ETH",
+                },
+                "BUSD/USDT:USDT": {
+                    "symbol": "BUSD/USDT:USDT",
+                    "linear": True,
+                    "swap": True,
+                    "quote": "USDT",
+                    "active": True,
+                    "base": "BUSD",
+                },
+            }
+
+    exchange = DummyExchange()
+    markets = exchange_utils.load_usdtm(exchange)
+    assert "ETH/USDT:USDT" in markets
+    assert "BUSD/USDT:USDT" not in markets
+
+
 def test_top_by_market_cap(monkeypatch):
     def fake_get(url, params=None, timeout=None):
         assert params["per_page"] == 2


### PR DESCRIPTION
## Summary
- avoid trading stablecoins by adding `STABLE_BASES` and incorporating them into `BLACKLIST_BASES`
- ensure `load_usdtm` removes stablecoin markets
- test that stablecoin markets are filtered

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab334cf770832399a89c04ec493464