### PR TITLE
Compact volume metrics and round price precision

### DIFF
--- a/payload_builder.py
+++ b/payload_builder.py
@@ -16,7 +16,7 @@ from threading import Lock
 import pandas as pd
 import requests
 
-from env_utils import compact, drop_empty, now_ms, rfloat
+from env_utils import compact, drop_empty, human_num, now_ms, rfloat
 from exchange_utils import (
     cvd_snapshot,
     fetch_ohlcv_df,
@@ -150,7 +150,7 @@ def build_1h(df: pd.DataFrame) -> Dict:
     data = add_indicators(df)
     tail20 = data.tail(20)
     ohlcv20 = [
-        compact([r.open, r.high, r.low, r.close, r.volume])
+        compact([r.open, r.high, r.low, r.close]) + [human_num(r.volume)]
         for _, r in tail20.iterrows()
     ]
     swing_high = rfloat(data["high"].tail(20).max())

--- a/tests/test_payload_builder.py
+++ b/tests/test_payload_builder.py
@@ -70,3 +70,73 @@ def test_build_1h_adds_volume(monkeypatch):
 
     res = payload_builder.build_1h(df)
     assert all(len(candle) == 5 for candle in res["ohlcv"])
+
+
+def test_build_1h_formats_large_volume(monkeypatch):
+    import pandas as pd
+
+    def fake_add_indicators(df):
+        for col in [
+            "ema20",
+            "ema50",
+            "ema99",
+            "ema200",
+            "rsi14",
+            "macd",
+            "macd_sig",
+            "macd_hist",
+            "atr14",
+            "vol_spike",
+        ]:
+            df[col] = 0.0
+        return df
+
+    monkeypatch.setattr(payload_builder, "add_indicators", fake_add_indicators)
+    monkeypatch.setattr(payload_builder, "detect_sr_levels", lambda df, lookback: [])
+
+    df = pd.DataFrame(
+        {
+            "open": [1.0, 2.0],
+            "high": [1.1, 2.1],
+            "low": [0.9, 1.9],
+            "close": [1.05, 2.05],
+            "volume": [100.0, 312066130.0],
+        },
+        index=pd.date_range("2024-01-01", periods=2, freq="H"),
+    )
+
+    res = payload_builder.build_1h(df)
+    assert res["ohlcv"][-1][-1] == "312M"
+
+
+def test_build_snap_rounds_price(monkeypatch):
+    import pandas as pd
+
+    def fake_add_indicators(df):
+        for col, val in [
+            ("ema20", 4270.7607),
+            ("ema50", 0.0),
+            ("ema99", 0.0),
+            ("ema200", 0.0),
+            ("rsi14", 0.0),
+            ("macd", 0.0),
+        ]:
+            df[col] = val
+        return df
+
+    monkeypatch.setattr(payload_builder, "add_indicators", fake_add_indicators)
+    monkeypatch.setattr(payload_builder, "trend_lbl", lambda *a, **k: "flat")
+
+    df = pd.DataFrame(
+        {
+            "open": [1.0],
+            "high": [1.1],
+            "low": [0.9],
+            "close": [1.05],
+            "volume": [100.0],
+        },
+        index=pd.date_range("2024-01-01", periods=1, freq="H"),
+    )
+
+    snap = payload_builder.build_snap(df)
+    assert snap["ema20"] == 4270.76


### PR DESCRIPTION
## Summary
- add `human_num` helper to format numbers like `312M`
- use `human_num` in OHLCV payload to compact volume entries
- lower float rounding precision to 6 significant digits so prices like `ema20` emit `4270.76`
- test that large volumes format with suffixes and that price snapshots round to reduced precision

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab38f19174832390feca25a45a5c4f