### PR TITLE
feat: add 15m scalping mode

### DIFF
--- a/prompts.py
+++ b/prompts.py
@@ -10,14 +10,11 @@ PROMPT_SYS_MINI = (
 )
 
 PROMPT_USER_MINI = (
-    "Dữ liệu đầy đủ dưới đây (không bỏ sót bất kỳ trường nào). "
-    "Phân tích toàn bộ như 1 trader chuyên nghiệp, kết hợp price action, đa khung (1H/H4/D1), ETH bias, "
-    "orderbook, funding/OI/CVD/liquidation, news. "
-    "Nếu phát hiện nguy cơ đảo chiều thì có thể đóng vị thế bằng hành động \"close_all\" hoặc \"close_partial\". "
-    "Trả về JSON duy nhất dạng {\"coins\":[{\"pair\":\"SYMBOL\",\"entry\":0.0,\"sl\":0.0,\"tp2\":0.0}],"
-    "\"close_all\":[{\"pair\":\"SYMBOL\"}],"
-    "\"close_partial\":[{\"pair\":\"SYMBOL\",\"pct\":50}]}. "
-    "Không có tín hiệu → {\"coins\":[],\"close_all\":[],\"close_partial\":[]}. "
+    "Dữ liệu 15m dưới đây cho các coin. "
+    "Phân tích toàn bộ như một trader chuyên nghiệp, kết hợp price action, đa khung (1H/H4/D1), ETH bias. "
+    "Chỉ vào lệnh khi độ tự tin > 7 và tỉ lệ RR tốt. "
+    "Trả về JSON duy nhất dạng {\\\"coins\\\":[{\\\"pair\\\":\\\"SYMBOL\\\",\\\"entry\\\":0.0,\\\"sl\\\":0.0,\\\"tp2\\\":0.0}]}. "
+    "Không có tín hiệu → {\\\"coins\\\":[]}. "
     "Chỉ chọn LIMIT entry tối ưu (best limit entry). "
     "DATA:{payload}"
 )

--- a/tests/test_build_payload.py
+++ b/tests/test_build_payload.py
@@ -12,8 +12,6 @@ class DummyExchange:
 
 def test_build_payload_fills_from_market_cap(monkeypatch):
     monkeypatch.setattr(pb, "positions_snapshot", lambda ex: [])
-    monkeypatch.setattr(pb, "eth_bias", lambda ex: {})
-    monkeypatch.setattr(pb, "news_snapshot", lambda: {})
     monkeypatch.setattr(pb, "coin_payload", lambda ex, sym: {"pair": pb.norm_pair_symbol(sym)})
     monkeypatch.setattr(pb, "top_by_qv", lambda ex, lim: ["AAA/USDT:USDT"])
     monkeypatch.setattr(pb, "top_by_market_cap", lambda lim: ["AAA", "BBB"])
@@ -33,8 +31,6 @@ def test_build_payload_fills_from_market_cap(monkeypatch):
 
 def test_build_payload_handles_numeric_prefix(monkeypatch):
     monkeypatch.setattr(pb, "positions_snapshot", lambda ex: [])
-    monkeypatch.setattr(pb, "eth_bias", lambda ex: {})
-    monkeypatch.setattr(pb, "news_snapshot", lambda: {})
     monkeypatch.setattr(pb, "coin_payload", lambda ex, sym: {"pair": pb.norm_pair_symbol(sym)})
     monkeypatch.setattr(pb, "top_by_qv", lambda ex, lim: [])
     monkeypatch.setattr(pb, "top_by_market_cap", lambda lim: ["PEPE"])

--- a/tests/test_futures_gpt_orchestrator_full.py
+++ b/tests/test_futures_gpt_orchestrator_full.py
@@ -1,5 +1,4 @@
 import json
-import json
 import os
 import pathlib
 import sys
@@ -14,7 +13,7 @@ class DummyExchange:
         return {"total": {"USDT": 1000}}
 
 
-def test_run_includes_positions_in_gpt_payload(monkeypatch):
+def test_run_sends_coins_only(monkeypatch):
     monkeypatch.setattr(orch, "load_env", lambda: None)
     monkeypatch.setattr(orch, "get_models", lambda: (None, "MODEL"))
     monkeypatch.setattr(orch, "ts_prefix", lambda: "ts")
@@ -28,15 +27,7 @@ def test_run_includes_positions_in_gpt_payload(monkeypatch):
 
     def fake_build_payload(ex, limit):
         build_called["called"] = True
-        return {
-            "time": {},
-            "eth": {},
-            "news": {},
-            "coins": [{"pair": "ETHUSDT"}, {"pair": "BTCUSDT"}],
-            "positions": [
-                {"pair": "ETHUSDT", "entry": 1, "sl": 0.9, "tp1": 1.1, "tp2": 1.2}
-            ],
-        }
+        return {"coins": [{"pair": "ETHUSDT"}, {"pair": "BTCUSDT"}]}
 
     monkeypatch.setattr(orch, "build_payload", fake_build_payload)
 
@@ -50,11 +41,7 @@ def test_run_includes_positions_in_gpt_payload(monkeypatch):
     monkeypatch.setattr(
         orch, "extract_content", lambda r: r["choices"][0]["message"]["content"]
     )
-    monkeypatch.setattr(
-        orch,
-        "parse_mini_actions",
-        lambda text: {"coins": [], "close_all": [], "close_partial": []},
-    )
+    monkeypatch.setattr(orch, "parse_mini_actions", lambda text: {"coins": []})
     monkeypatch.setattr(orch, "enrich_tp_qty", lambda ex, coins, capital: coins)
 
     res = orch.run(run_live=False, ex=DummyExchange())
@@ -63,21 +50,15 @@ def test_run_includes_positions_in_gpt_payload(monkeypatch):
     payload_str = captured.get("user", "").split("DATA:")[-1]
     data = json.loads(payload_str)
     assert any(c.get("pair") == "ETHUSDT" for c in data.get("coins", []))
-    assert any(p.get("pair") == "ETHUSDT" for p in data.get("positions", []))
+    assert "positions" not in data
     assert res == {
         "ts": "ts",
         "live": False,
         "capital": 1000.0,
         "coins": [],
-        "close_all": [],
-        "close_partial": [],
         "placed": [],
-        "closed": [],
     }
     assert "ts_orders.json" in fake_save_text.saved
     data = json.loads(fake_save_text.saved["ts_orders.json"])
-    assert "reason" not in data
     assert data["coins"] == []
-    assert data["close_all"] == []
-    assert data["close_partial"] == []
-    assert data["closed"] == []
+    assert data["placed"] == []

--- a/tests/test_payload_builder.py
+++ b/tests/test_payload_builder.py
@@ -3,59 +3,17 @@ import sys
 
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
 import payload_builder  # noqa: E402
-import requests  # noqa: E402
 
 
-class DummyResponse:
-    def __init__(self, data):
-        self._data = data
-
-    def json(self):
-        return self._data
-
-    def raise_for_status(self):
-        pass
-
-
-def test_news_snapshot(monkeypatch):
-    def fake_get(url, params=None, timeout=None, headers=None):
-        assert "auth_token" in params
-        data = {
-            "results": [
-                {"title": "A", "domain": "d1"},
-                {"title": "B" * 130, "domain": "d2"},
-            ]
-        }
-        return DummyResponse(data)
-
-    monkeypatch.setenv("NEWS_API_KEY", "key")
-    monkeypatch.setattr(requests, "get", fake_get)
-    snap = payload_builder.news_snapshot()
-    long_headline = "B" * 120 + "…"
-    assert snap == {"news": f"A – d1 • {long_headline}"}
-
-
-def test_build_1h_adds_volume(monkeypatch):
+def test_build_15m_adds_volume(monkeypatch):
     import pandas as pd
 
     def fake_add_indicators(df):
-        for col in [
-            "ema20",
-            "ema50",
-            "ema99",
-            "ema200",
-            "rsi14",
-            "macd",
-            "macd_sig",
-            "macd_hist",
-            "atr14",
-            "vol_spike",
-        ]:
+        for col in ["ema20", "ema50", "ema200", "rsi14", "macd"]:
             df[col] = 0.0
         return df
 
     monkeypatch.setattr(payload_builder, "add_indicators", fake_add_indicators)
-    monkeypatch.setattr(payload_builder, "detect_sr_levels", lambda df, lookback: [])
 
     df = pd.DataFrame(
         {
@@ -65,34 +23,22 @@ def test_build_1h_adds_volume(monkeypatch):
             "close": [1.05, 2.05],
             "volume": [100.0, 200.0],
         },
-        index=pd.date_range("2024-01-01", periods=2, freq="H"),
+        index=pd.date_range("2024-01-01", periods=2, freq="15T"),
     )
 
-    res = payload_builder.build_1h(df)
+    res = payload_builder.build_15m(df)
     assert all(len(candle) == 5 for candle in res["ohlcv"])
 
 
-def test_build_1h_formats_large_volume(monkeypatch):
+def test_build_15m_formats_large_volume(monkeypatch):
     import pandas as pd
 
     def fake_add_indicators(df):
-        for col in [
-            "ema20",
-            "ema50",
-            "ema99",
-            "ema200",
-            "rsi14",
-            "macd",
-            "macd_sig",
-            "macd_hist",
-            "atr14",
-            "vol_spike",
-        ]:
+        for col in ["ema20", "ema50", "ema200", "rsi14", "macd"]:
             df[col] = 0.0
         return df
 
     monkeypatch.setattr(payload_builder, "add_indicators", fake_add_indicators)
-    monkeypatch.setattr(payload_builder, "detect_sr_levels", lambda df, lookback: [])
 
     df = pd.DataFrame(
         {
@@ -102,10 +48,10 @@ def test_build_1h_formats_large_volume(monkeypatch):
             "close": [1.05, 2.05],
             "volume": [100.0, 312066130.0],
         },
-        index=pd.date_range("2024-01-01", periods=2, freq="H"),
+        index=pd.date_range("2024-01-01", periods=2, freq="15T"),
     )
 
-    res = payload_builder.build_1h(df)
+    res = payload_builder.build_15m(df)
     assert res["ohlcv"][-1][-1] == "312M"
 
 
@@ -135,7 +81,7 @@ def test_build_snap_rounds_price(monkeypatch):
             "close": [1.05],
             "volume": [100.0],
         },
-        index=pd.date_range("2024-01-01", periods=1, freq="H"),
+        index=pd.date_range("2024-01-01", periods=1, freq="15T"),
     )
 
     snap = payload_builder.build_snap(df)


### PR DESCRIPTION
## Summary
- support 15m-only payloads and coin selection
- simplify orchestrator to place new orders only
- trim prompts for 15m analysis
- require trades to have confidence >7 with good RR and restore pro multi-timeframe guidance

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68abe411c3c88323b3d0e5e00276f270