### PR TITLE
feat: cache market cap lookups

### DIFF
--- a/payload_builder.py
+++ b/payload_builder.py
@@ -103,14 +103,19 @@ def coin_payload(exchange, symbol: str) -> Dict:
     return drop_empty(payload)
 
 
-def build_payload(exchange, limit: int = 10, exclude_pairs: Set[str] | None = None) -> Dict:
+def build_payload(
+    exchange,
+    limit: int = 10,
+    exclude_pairs: Set[str] | None = None,
+    mc_ttl: float = 3600,
+) -> Dict:
     """Build the payload used by the orchestrator (15m only)."""
 
     exclude_pairs = exclude_pairs or set()
     positions = positions_snapshot(exchange)
     pos_pairs = {p.get("pair") for p in positions}
     symbols_raw = top_by_qv(exchange, limit * 2)
-    mc_list = top_by_market_cap(max(limit, 30))
+    mc_list = top_by_market_cap(max(limit, 30), ttl=mc_ttl)
     mc_bases = set(mc_list)
     symbols: List[str] = []
     used_bases: Set[str] = set()

--- a/tests/test_build_payload.py
+++ b/tests/test_build_payload.py
@@ -14,7 +14,7 @@ def test_build_payload_fills_from_market_cap(monkeypatch):
     monkeypatch.setattr(pb, "positions_snapshot", lambda ex: [])
     monkeypatch.setattr(pb, "coin_payload", lambda ex, sym: {"pair": pb.norm_pair_symbol(sym)})
     monkeypatch.setattr(pb, "top_by_qv", lambda ex, lim: ["AAA/USDT:USDT"])
-    monkeypatch.setattr(pb, "top_by_market_cap", lambda lim: ["AAA", "BBB"])
+    monkeypatch.setattr(pb, "top_by_market_cap", lambda lim, ttl=3600: ["AAA", "BBB"])
     monkeypatch.setattr(
         pb,
         "load_usdtm",
@@ -33,7 +33,7 @@ def test_build_payload_handles_numeric_prefix(monkeypatch):
     monkeypatch.setattr(pb, "positions_snapshot", lambda ex: [])
     monkeypatch.setattr(pb, "coin_payload", lambda ex, sym: {"pair": pb.norm_pair_symbol(sym)})
     monkeypatch.setattr(pb, "top_by_qv", lambda ex, lim: [])
-    monkeypatch.setattr(pb, "top_by_market_cap", lambda lim: ["PEPE"])
+    monkeypatch.setattr(pb, "top_by_market_cap", lambda lim, ttl=3600: ["PEPE"])
     monkeypatch.setattr(
         pb,
         "load_usdtm",

--- a/tests/test_exchange_utils.py
+++ b/tests/test_exchange_utils.py
@@ -46,10 +46,18 @@ def test_load_usdtm_filters_stablecoins():
 
 
 def test_top_by_market_cap(monkeypatch):
+    calls = []
+
     def fake_get(url, params=None, timeout=None):
+        calls.append(1)
         assert params["per_page"] == 2
         return DummyResponse([{"symbol": "btc"}, {"symbol": "eth"}])
 
     monkeypatch.setattr(requests, "get", fake_get)
-    res = exchange_utils.top_by_market_cap(2)
-    assert res == ["BTC", "ETH"]
+    exchange_utils._MCAP_CACHE["timestamp"] = 0
+    exchange_utils._MCAP_CACHE["data"] = []
+    res1 = exchange_utils.top_by_market_cap(2)
+    res2 = exchange_utils.top_by_market_cap(2)
+    assert res1 == ["BTC", "ETH"]
+    assert res2 == ["BTC", "ETH"]
+    assert len(calls) == 1


### PR DESCRIPTION
## Summary
- cache CoinGecko market cap results with in-memory TTL to avoid redundant requests
- allow payload builder to pass through a configurable TTL for market cap lookups
- adjust tests for new caching behaviour

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68abef57065c8323a633f1a8c620c4f5