### PR TITLE
docs: mention 15m focus in orchestrator

### DIFF
--- a/futures_gpt_orchestrator_full.py
+++ b/futures_gpt_orchestrator_full.py
@@ -1,4 +1,4 @@
-"""Futures → GPT Orchestrator (1h base, H4/D1, ETH bias).
+"""Futures → GPT Orchestrator (15m focus, H4/D1 context; retains ETH bias).
 
 This script orchestrates the flow:
 1. Build payloads from market data


### PR DESCRIPTION
## Summary
- clarify futures orchestrator now emphasizes 15m focus and notes ETH bias retention

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68abefb51ad883238493ffc1cd6ca022