### PR TITLE
Add session time info, order book stats, and ETH bias to payload

### DIFF
--- a/tests/test_build_payload.py
+++ b/tests/test_build_payload.py
@@ -23,10 +23,12 @@ def test_build_payload_fills_from_market_cap(monkeypatch):
             "BBB/USDT:USDT": {"base": "BBB"},
         },
     )
+    monkeypatch.setattr(pb, "_snap_with_cache", lambda *a, **k: {"ema": 0})
 
     payload = pb.build_payload(DummyExchange(), limit=2)
     pairs = {c["pair"] for c in payload["coins"]}
     assert pairs == {"AAAUSDT", "BBBUSDT"}
+    assert "time" in payload and "eth" in payload
 
 
 def test_build_payload_handles_numeric_prefix(monkeypatch):
@@ -39,7 +41,9 @@ def test_build_payload_handles_numeric_prefix(monkeypatch):
         "load_usdtm",
         lambda ex: {"1000PEPE/USDT:USDT": {"base": "1000PEPE"}},
     )
+    monkeypatch.setattr(pb, "_snap_with_cache", lambda *a, **k: {"ema": 0})
 
     payload = pb.build_payload(DummyExchange(), limit=1)
     pairs = {c["pair"] for c in payload["coins"]}
     assert pairs == {"1000PEPEUSDT"}
+    assert "time" in payload and "eth" in payload

--- a/tests/test_payload_builder.py
+++ b/tests/test_payload_builder.py
@@ -146,6 +146,19 @@ def test_coin_payload_includes_higher_timeframes(monkeypatch):
     monkeypatch.setattr(payload_builder, "fetch_ohlcv_df", fake_fetch)
     monkeypatch.setattr(payload_builder, "add_indicators", fake_add_indicators)
     monkeypatch.setattr(payload_builder, "trend_lbl", lambda *a, **k: "flat")
+    monkeypatch.setattr(payload_builder, "orderbook_snapshot", lambda ex, sym: {"spread": 0.1})
 
     res = payload_builder.coin_payload(None, "BTC/USDT:USDT")
-    assert "h1" in res and "h4" in res
+    assert "h1" in res and "h4" in res and res["ob"]["spread"] == 0.1
+
+
+def test_time_payload_sessions():
+    from datetime import datetime, timezone
+
+    now = datetime(2024, 1, 1, 2, 0, tzinfo=timezone.utc)
+    asia = payload_builder.time_payload(now)
+    assert asia["session"] == "asia" and asia["utc_hour"] == 2
+
+    now = datetime(2024, 1, 1, 18, 0, tzinfo=timezone.utc)
+    us = payload_builder.time_payload(now)
+    assert us["session"] == "us" and us["mins_to_close"] == 360


### PR DESCRIPTION
## Summary
- enrich payloads with UTC session metadata for filtering
- include order book spread/volume/imbalance in each coin snapshot
- provide dedicated ETH h1/h4 bias block

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68abf62769848323b701f67ba6e70a2f