### PR TITLE
feat: support three-stage take-profit with entry stop move

### DIFF
--- a/positions.py
+++ b/positions.py
@@ -69,6 +69,7 @@ def positions_snapshot(exchange) -> List[Dict]:
         sl = None
         tp1 = None
         tp2 = None
+        tp3 = None
         try:
             orders = exchange.fetch_open_orders(sym)
         except Exception:
@@ -91,6 +92,8 @@ def positions_snapshot(exchange) -> List[Dict]:
             tp1 = rfloat(prices[0])
         if len(prices) >= 2:
             tp2 = rfloat(prices[1])
+        if len(prices) >= 3:
+            tp3 = rfloat(prices[2])
         out.append(
             drop_empty(
                 {
@@ -100,6 +103,7 @@ def positions_snapshot(exchange) -> List[Dict]:
                     "sl": sl,
                     "tp1": tp1,
                     "tp2": tp2,
+                    "tp3": tp3,
                 }
             )
         )

--- a/tests/test_futures_gpt_orchestrator_full.py
+++ b/tests/test_futures_gpt_orchestrator_full.py
@@ -77,9 +77,10 @@ def test_run_sends_coins_only(monkeypatch):
 @pytest.mark.parametrize("side,exit_side", [("buy", "sell"), ("sell", "buy")])
 def test_place_sl_tp(side, exit_side):
     ex = CaptureExchange()
-    orch._place_sl_tp(ex, "BTC/USDT", side, 10, 1, 2, 3)
+    orch._place_sl_tp(ex, "BTC/USDT", side, 10, 1, 2, 3, 4)
     assert ex.orders == [
         ("BTC/USDT", "stop", exit_side, 10, 1, {"stopPrice": 1, "reduceOnly": True}),
-        ("BTC/USDT", "limit", exit_side, 2.0, 2, {"reduceOnly": True}),
-        ("BTC/USDT", "limit", exit_side, 8.0, 3, {"reduceOnly": True}),
+        ("BTC/USDT", "limit", exit_side, 3.0, 2, {"reduceOnly": True}),
+        ("BTC/USDT", "limit", exit_side, 5.0, 3, {"reduceOnly": True}),
+        ("BTC/USDT", "limit", exit_side, 2.0, 4, {"reduceOnly": True}),
     ]

--- a/tests/test_trading_utils.py
+++ b/tests/test_trading_utils.py
@@ -22,11 +22,12 @@ def test_to_ccxt_symbol_with_exchange_markets():
 def test_parse_mini_actions_handles_close():
     text = (
         "{"
-        '"coins":[{"pair":"BTCUSDT","entry":1,"sl":0.9,"tp2":1.1}],'
+        '"coins":[{"pair":"BTCUSDT","entry":1,"sl":0.9,"tp1":1.05,"tp2":1.1,"tp3":1.2}],'
         '"close_all":[{"pair":"ETHUSDT"}],'
         '"close_partial":[{"pair":"LTCUSDT","pct":25}]}'
     )
     res = trading_utils.parse_mini_actions(text)
     assert res["coins"] and res["coins"][0]["pair"] == "BTCUSDT"
+    assert res["coins"][0]["tp3"] == 1.2
     assert res["close_all"] == [{"pair": "ETHUSDT"}]
     assert res["close_partial"] == [{"pair": "LTCUSDT", "pct": 25.0}]


### PR DESCRIPTION
## Summary
- allow GPT to return tp1-tp3 and default to 1R/2R/3R
- split position 30/50/20 and place three TP orders
- move stop to entry after first TP fills and expose tp3 in position snapshots

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68ac056e53bc8323806831acb874c1fc