### PR TITLE
feat: support triple take-profit and stop adjustment

### DIFF
--- a/positions.py
+++ b/positions.py
@@ -69,6 +69,7 @@ def positions_snapshot(exchange) -> List[Dict]:
         sl = None
         tp1 = None
         tp2 = None
+        tp3 = None
         try:
             orders = exchange.fetch_open_orders(sym)
         except Exception:
@@ -91,6 +92,8 @@ def positions_snapshot(exchange) -> List[Dict]:
             tp1 = rfloat(prices[0])
         if len(prices) >= 2:
             tp2 = rfloat(prices[1])
+        if len(prices) >= 3:
+            tp3 = rfloat(prices[2])
         out.append(
             drop_empty(
                 {
@@ -100,6 +103,7 @@ def positions_snapshot(exchange) -> List[Dict]:
                     "sl": sl,
                     "tp1": tp1,
                     "tp2": tp2,
+                    "tp3": tp3,
                 }
             )
         )

--- a/prompts.py
+++ b/prompts.py
@@ -13,7 +13,7 @@ PROMPT_USER_MINI = (
     "Dữ liệu 15m dưới đây cho các coin. "
     "Phân tích toàn bộ như một trader chuyên nghiệp, kết hợp price action, đa khung (1H/H4/D1), ETH bias. "
     "Chỉ vào lệnh khi độ tự tin > 7 và tỉ lệ RR tốt. "
-    "Trả về JSON duy nhất dạng {\\\"coins\\\":[{\\\"pair\\\":\\\"SYMBOL\\\",\\\"entry\\\":0.0,\\\"sl\\\":0.0,\\\"tp2\\\":0.0}]}. "
+    "Trả về JSON duy nhất với 3 mức chốt lời tp1,tp2,tp3 dạng {\\\"coins\\\":[{\\\"pair\\\":\\\"SYMBOL\\\",\\\"entry\\\":0.0,\\\"sl\\\":0.0,\\\"tp1\\\":0.0,\\\"tp2\\\":0.0,\\\"tp3\\\":0.0}]}. "
     "Không có tín hiệu → {\\\"coins\\\":[]}. "
     "Chỉ chọn LIMIT entry tối ưu (best limit entry). "
     "DATA:{payload}"

--- a/tests/test_futures_gpt_orchestrator_full.py
+++ b/tests/test_futures_gpt_orchestrator_full.py
@@ -77,9 +77,10 @@ def test_run_sends_coins_only(monkeypatch):
 @pytest.mark.parametrize("side,exit_side", [("buy", "sell"), ("sell", "buy")])
 def test_place_sl_tp(side, exit_side):
     ex = CaptureExchange()
-    orch._place_sl_tp(ex, "BTC/USDT", side, 10, 1, 2, 3)
+    orch._place_sl_tp(ex, "BTC/USDT", side, 10, 1, 2, 3, 4)
     assert ex.orders == [
         ("BTC/USDT", "stop", exit_side, 10, 1, {"stopPrice": 1, "reduceOnly": True}),
-        ("BTC/USDT", "limit", exit_side, 2.0, 2, {"reduceOnly": True}),
-        ("BTC/USDT", "limit", exit_side, 8.0, 3, {"reduceOnly": True}),
+        ("BTC/USDT", "limit", exit_side, 3.0, 2, {"reduceOnly": True}),
+        ("BTC/USDT", "limit", exit_side, 5.0, 3, {"reduceOnly": True}),
+        ("BTC/USDT", "limit", exit_side, 2.0, 4, {"reduceOnly": True}),
     ]

--- a/tests/test_trading_utils.py
+++ b/tests/test_trading_utils.py
@@ -22,11 +22,12 @@ def test_to_ccxt_symbol_with_exchange_markets():
 def test_parse_mini_actions_handles_close():
     text = (
         "{"
-        '"coins":[{"pair":"BTCUSDT","entry":1,"sl":0.9,"tp2":1.1}],'
+        '"coins":[{"pair":"BTCUSDT","entry":1,"sl":0.9,"tp1":1.05,"tp2":1.1,"tp3":1.2}],'
         '"close_all":[{"pair":"ETHUSDT"}],'
         '"close_partial":[{"pair":"LTCUSDT","pct":25}]}'
     )
     res = trading_utils.parse_mini_actions(text)
     assert res["coins"] and res["coins"][0]["pair"] == "BTCUSDT"
+    assert res["coins"][0]["tp3"] == 1.2
     assert res["close_all"] == [{"pair": "ETHUSDT"}]
     assert res["close_partial"] == [{"pair": "LTCUSDT", "pct": 25.0}]


### PR DESCRIPTION
## Summary
- support three take-profit targets with default 1R/2R/3R levels
- move stop-loss to entry after TP1 and split exits 30/50/20
- document tp1/tp2/tp3 requirements in prompt

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac056e53bc8323806831acb874c1fc