### PR TITLE
Use limit orders for SL/TP to reduce fees

### DIFF
--- a/positions.py
+++ b/positions.py
@@ -77,15 +77,23 @@ def positions_snapshot(exchange) -> List[Dict]:
         sl_orders = [
             o
             for o in orders
-            if (o.get("type") or "").lower() == "stop" and o.get("reduceOnly")
+            if (o.get("type") or "").lower() == "limit"
+            and o.get("reduceOnly")
+            and (o.get("stopPrice") or (o.get("info") or {}).get("stopPrice"))
         ]
         tp_orders = [
             o
             for o in orders
-            if (o.get("type") or "").lower() == "limit" and o.get("reduceOnly")
+            if (o.get("type") or "").lower() == "limit"
+            and o.get("reduceOnly")
+            and not (o.get("stopPrice") or (o.get("info") or {}).get("stopPrice"))
         ]
         if sl_orders:
-            sl = rfloat(sl_orders[0].get("stopPrice") or sl_orders[0].get("price"))
+            sl = rfloat(
+                sl_orders[0].get("stopPrice")
+                or (sl_orders[0].get("info") or {}).get("stopPrice")
+                or sl_orders[0].get("price")
+            )
         prices = [float(o.get("price") or 0) for o in tp_orders]
         prices.sort(reverse=(side == "sell"))
         if len(prices) >= 1:

--- a/tests/test_futures_gpt_orchestrator_full.py
+++ b/tests/test_futures_gpt_orchestrator_full.py
@@ -79,7 +79,7 @@ def test_place_sl_tp(side, exit_side):
     ex = CaptureExchange()
     orch._place_sl_tp(ex, "BTC/USDT", side, 10, 1, 2, 3, 4)
     assert ex.orders == [
-        ("BTC/USDT", "stop", exit_side, 10, 1, {"stopPrice": 1, "reduceOnly": True}),
+        ("BTC/USDT", "limit", exit_side, 10, 1, {"stopPrice": 1, "reduceOnly": True}),
         ("BTC/USDT", "limit", exit_side, 3.0, 2, {"reduceOnly": True}),
         ("BTC/USDT", "limit", exit_side, 5.0, 3, {"reduceOnly": True}),
         ("BTC/USDT", "limit", exit_side, 2.0, 4, {"reduceOnly": True}),


### PR DESCRIPTION
## Summary
- Switch stop-loss orders from `stop` to `limit` with `stopPrice` to lower fees
- Detect stop-loss vs. take-profit by checking for `stopPrice`
- Replace market TP1 fill with a limit order to avoid taker fees

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac0a096b9c83239ff0a41c10fabbc2