### PR TITLE
Handle errors in scheduled jobs with logging

### DIFF
--- a/futures_gpt_orchestrator_full.py
+++ b/futures_gpt_orchestrator_full.py
@@ -375,15 +375,24 @@ def live_loop(
     scheduler = sched.scheduler(time.time, time.sleep)
 
     def run_job():
-        run(run_live=True, limit=limit, ex=ex)
+        try:
+            run(run_live=True, limit=limit, ex=ex)
+        except Exception:
+            logger.exception("run_job error")
         scheduler.enter(run_interval, 1, run_job)
 
     def sl_job():
-        move_sl_to_entry_if_tp1_hit(ex)
+        try:
+            move_sl_to_entry_if_tp1_hit(ex)
+        except Exception:
+            logger.exception("sl_job error")
         scheduler.enter(sl_interval, 1, sl_job)
 
     def cancel_job():
-        cancel_unpositioned_limits(ex)
+        try:
+            cancel_unpositioned_limits(ex)
+        except Exception:
+            logger.exception("cancel_job error")
         scheduler.enter(cancel_interval, 1, cancel_job)
 
     scheduler.enter(0, 1, run_job)


### PR DESCRIPTION
## Summary
- Ensure `run_job`, `sl_job`, and `cancel_job` catch exceptions and log errors
- Continue scheduling jobs even when errors occur

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac24f5a0e88323a0fa707220b311b8