### PR TITLE
log exceptions instead of silent pass

### DIFF
--- a/exchange_utils.py
+++ b/exchange_utils.py
@@ -5,12 +5,16 @@ from __future__ import annotations
 import os
 import time
 from typing import Dict, List
+import logging
 
 import ccxt
 import pandas as pd
 import requests
 
 from env_utils import rfloat
+
+
+logger = logging.getLogger(__name__)
 
 # Stablecoins that should not be traded
 STABLE_BASES = {
@@ -76,7 +80,8 @@ def top_by_qv(exchange: ccxt.Exchange, limit: int = 20) -> List[str]:
             scored.append((sym, float(qv)))
         scored.sort(key=lambda x: x[1], reverse=True)
         return [s for s, _ in scored[:limit]]
-    except Exception:
+    except Exception as e:
+        logger.warning("top_by_qv error: %s", e)
         return symbols[:limit]
 
 
@@ -110,7 +115,8 @@ def top_by_market_cap(limit: int = 30, *, ttl: float = 3600) -> List[str]:
         _MCAP_CACHE["timestamp"] = now
         _MCAP_CACHE["data"] = symbols
         return symbols
-    except Exception:
+    except Exception as e:
+        logger.warning("top_by_market_cap error: %s", e)
         return cached[:limit] if cached else []
 
 
@@ -152,7 +158,8 @@ def orderbook_snapshot(exchange: ccxt.Exchange, symbol: str, depth: int = 10) ->
             "a": rfloat(ask_vol, 6),
             "im": rfloat(imb, 6),
         }
-    except Exception:
+    except Exception as e:
+        logger.warning("orderbook_snapshot error for %s: %s", symbol, e)
         return {}
 
 
@@ -170,7 +177,8 @@ def funding_snapshot(exchange: ccxt.Exchange, symbol: str) -> Dict:
             "predicted_rate": rfloat(predicted, 6),
             "next_ts": int(next_ts) if next_ts else None,
         }
-    except Exception:
+    except Exception as e:
+        logger.warning("funding_snapshot error for %s: %s", symbol, e)
         return {}
 
 
@@ -191,7 +199,8 @@ def open_interest_snapshot(exchange: ccxt.Exchange, symbol: str) -> Dict:
         if value is not None:
             out["value"] = rfloat(value, 6)
         return out
-    except Exception:
+    except Exception as e:
+        logger.warning("open_interest_snapshot error for %s: %s", symbol, e)
         return {}
 
 
@@ -209,7 +218,8 @@ def cvd_snapshot(exchange: ccxt.Exchange, symbol: str, limit: int = 500) -> Dict
             elif side == "sell":
                 cvd -= amt
         return {"cvd": rfloat(cvd, 6)}
-    except Exception:
+    except Exception as e:
+        logger.warning("cvd_snapshot error for %s: %s", symbol, e)
         return {}
 
 
@@ -233,6 +243,7 @@ def liquidation_snapshot(
             "long_liq": rfloat(long_amt, 6),
             "short_liq": rfloat(short_amt, 6),
         }
-    except Exception:
+    except Exception as e:
+        logger.warning("liquidation_snapshot error for %s: %s", symbol, e)
         return {}
 

--- a/positions.py
+++ b/positions.py
@@ -3,8 +3,12 @@
 from __future__ import annotations
 
 from typing import Dict, List, Set
+import logging
 
 from env_utils import drop_empty, rfloat
+
+
+logger = logging.getLogger(__name__)
 
 
 def _norm_pair_from_symbol(symbol: str) -> str:
@@ -33,10 +37,11 @@ def get_open_position_pairs(exchange) -> Set[str]:
             try:
                 if abs(float(amt)) > 0:
                     out.add(pair)
-            except Exception:
+            except Exception as e:
+                logger.warning("get_open_position_pairs amt parse error: %s", e)
                 continue
-    except Exception:
-        pass
+    except Exception as e:
+        logger.warning("get_open_position_pairs fetch_positions error: %s", e)
     return out
 
 
@@ -46,7 +51,8 @@ def positions_snapshot(exchange) -> List[Dict]:
     out: List[Dict] = []
     try:
         positions = exchange.fetch_positions()
-    except Exception:
+    except Exception as e:
+        logger.warning("positions_snapshot fetch_positions error: %s", e)
         return out
 
     for p in positions or []:
@@ -61,7 +67,8 @@ def positions_snapshot(exchange) -> List[Dict]:
         try:
             amt_val = float(amt)
             entry_price = float(entry)
-        except Exception:
+        except Exception as e:
+            logger.warning("positions_snapshot parse error for %s: %s", pair, e)
             continue
         if amt_val == 0:
             continue
@@ -72,7 +79,8 @@ def positions_snapshot(exchange) -> List[Dict]:
         tp3 = None
         try:
             orders = exchange.fetch_open_orders(sym)
-        except Exception:
+        except Exception as e:
+            logger.warning("positions_snapshot fetch_open_orders error for %s: %s", sym, e)
             orders = []
         sl_orders = [
             o


### PR DESCRIPTION
## Summary
- add module-level loggers and record previously swallowed exceptions
- keep workflows running but provide warnings about balance, orderbook, and position errors

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ac24ef7bd88323bde0984a0a9dbbe3