### PR TITLE
Parse conf and rr fields from GPT responses

### DIFF
--- a/prompts.py
+++ b/prompts.py
@@ -13,7 +13,7 @@ PROMPT_USER_MINI = (
     "Dữ liệu 15m dưới đây cho các coin. "
     "Phân tích toàn bộ như một trader chuyên nghiệp, kết hợp price action, đa khung (1H/H4/D1), ETH bias. "
     "Chỉ vào lệnh khi độ tự tin > 7 và tỉ lệ RR tốt. "
-    "Trả về JSON duy nhất với 3 mức chốt lời tp1,tp2,tp3 dạng {\\\"coins\\\":[{\\\"pair\\\":\\\"SYMBOL\\\",\\\"entry\\\":0.0,\\\"sl\\\":0.0,\\\"tp1\\\":0.0,\\\"tp2\\\":0.0,\\\"tp3\\\":0.0}]}. "
+    "Trả về JSON duy nhất với 3 mức chốt lời tp1,tp2,tp3 và kèm conf (0-10) cùng rr (tỉ lệ R/R) dạng {\\\"coins\\\":[{\\\"pair\\\":\\\"SYMBOL\\\",\\\"entry\\\":0.0,\\\"sl\\\":0.0,\\\"tp1\\\":0.0,\\\"tp2\\\":0.0,\\\"tp3\\\":0.0,\\\"conf\\\":0,\\\"rr\\\":0.0}]}. "
     "Không có tín hiệu → {\\\"coins\\\":[]}. "
     "Chỉ chọn LIMIT entry tối ưu (best limit entry). "
     "DATA:{payload}"

--- a/tests/test_trading_utils.py
+++ b/tests/test_trading_utils.py
@@ -22,12 +22,14 @@ def test_to_ccxt_symbol_with_exchange_markets():
 def test_parse_mini_actions_handles_close():
     text = (
         "{"
-        '"coins":[{"pair":"BTCUSDT","entry":1,"sl":0.9,"tp1":1.05,"tp2":1.1,"tp3":1.2}],'
+        '"coins":[{"pair":"BTCUSDT","entry":1,"sl":0.9,"tp1":1.05,"tp2":1.1,"tp3":1.2,"conf":8,"rr":2.5}],'
         '"close_all":[{"pair":"ETHUSDT"}],'
         '"close_partial":[{"pair":"LTCUSDT","pct":25}]}'
     )
     res = trading_utils.parse_mini_actions(text)
     assert res["coins"] and res["coins"][0]["pair"] == "BTCUSDT"
     assert res["coins"][0]["tp3"] == 1.2
+    assert res["coins"][0]["conf"] == 8.0
+    assert res["coins"][0]["rr"] == 2.5
     assert res["close_all"] == [{"pair": "ETHUSDT"}]
     assert res["close_partial"] == [{"pair": "LTCUSDT", "pct": 25.0}]

--- a/trading_utils.py
+++ b/trading_utils.py
@@ -38,6 +38,8 @@ def parse_mini_actions(text: str) -> Dict[str, List[Dict[str, Any]]]:
         tp2 = item.get("tp2")
         tp3 = item.get("tp3")
         risk = item.get("risk")
+        conf = item.get("conf")
+        rr = item.get("rr")
         try:
             entry = float(entry) if entry is not None else None
             sl = float(sl) if sl is not None else None
@@ -45,6 +47,8 @@ def parse_mini_actions(text: str) -> Dict[str, List[Dict[str, Any]]]:
             tp2 = float(tp2) if tp2 not in (None, "") else None
             tp3 = float(tp3) if tp3 not in (None, "") else None
             risk = float(risk) if risk not in (None, "") else None
+            conf = float(conf) if conf not in (None, "") else None
+            rr = float(rr) if rr not in (None, "") else None
         except Exception:
             continue
         if None in (entry, sl) or entry == sl:
@@ -69,6 +73,8 @@ def parse_mini_actions(text: str) -> Dict[str, List[Dict[str, Any]]]:
                 "tp2": tp2,
                 "tp3": tp3,
                 "risk": risk,
+                "conf": conf,
+                "rr": rr,
             }
         )
 


### PR DESCRIPTION
## Summary
- Ask GPT to return confidence and risk/reward fields
- Parse `conf` and `rr` from model output and expose them in trade actions
- Test parsing of new fields

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac2be8e7dc8323a3c0e635c30cbf61