### PR TITLE
Handle open order warnings in orchestrator

### DIFF
--- a/futures_gpt_orchestrator_full.py
+++ b/futures_gpt_orchestrator_full.py
@@ -224,7 +224,13 @@ def cancel_unpositioned_limits(exchange, max_age_sec: int = 600):
         "Checking for stale limit orders older than %s seconds", max_age_sec
     )
     try:
+        # Suppress CCXT warning when fetching all open orders without a symbol
+        exchange.options["warnOnFetchOpenOrdersWithoutSymbol"] = False
+        logger.info(
+            "Fetching all open orders with warnOnFetchOpenOrdersWithoutSymbol=False"
+        )
         orders = exchange.fetch_open_orders()
+        logger.info("Fetched %d open orders", len(orders or []))
     except Exception as e:
         logger.warning("cancel_unpositioned_limits fetch_open_orders error: %s", e)
         return


### PR DESCRIPTION
## Summary
- Suppress CCXT warnings when fetching all open orders
- Add logging for the number of open orders retrieved

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ac87da1d0c832390b2050f20b5f640