### PR TITLE
Persist GPT limits per coin and schedule SL/TP placement

### DIFF
--- a/exchange_utils.py
+++ b/exchange_utils.py
@@ -30,7 +30,7 @@ STABLE_BASES = {
 }
 
 # Symbols to skip when building the market universe
-BLACKLIST_BASES = {"BTC", "BNB", "ETH"} | STABLE_BASES
+BLACKLIST_BASES = {"BTC", "BNB"} | STABLE_BASES
 
 
 # Cache for CoinGecko market cap results


### PR DESCRIPTION
## Summary
- save each GPT decision to a per-coin JSON file with limit and SL/TP targets
- add background job to read these files every minute and place SL/TP orders once entries fill
- allow ETH markets by removing it from the blacklist and add test coverage for JSON-based SL/TP

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ad28761a5c832385c752062c622615