### PR TITLE
Ensure save_text handles nested paths and streamline order directories

### DIFF
--- a/env_utils.py
+++ b/env_utils.py
@@ -86,15 +86,13 @@ def dumps_min(obj: Any) -> str:
 
 
 def save_text(path: str, text: str, folder: str = "outputs") -> None:
-    """
-    Persist text to ``folder/path`` using UTF-8 encoding.
-    Tự tạo folder nếu chưa tồn tại.
-    """
-    # Tạo đối tượng Path trỏ đến folder + filename
-    folder_path = Path(folder)
-    folder_path.mkdir(parents=True, exist_ok=True)  # đảm bảo folder tồn tại
+    """Persist ``text`` to ``folder/path`` using UTF-8 encoding.
 
-    file_path = folder_path / path
+    Any missing parent directories are created automatically, allowing
+    ``path`` to include nested folders (e.g. ``"limit_orders/foo.json"``).
+    """
+    file_path = Path(folder) / path
+    file_path.parent.mkdir(parents=True, exist_ok=True)
     file_path.write_text(text, encoding="utf-8")
 
 

--- a/tests/test_env_utils.py
+++ b/tests/test_env_utils.py
@@ -1,0 +1,8 @@
+from env_utils import save_text
+
+
+def test_save_text_creates_nested_dirs(tmp_path):
+    save_text("limit_orders/HYPEUSDT.json", "hello", folder=str(tmp_path))
+    target = tmp_path / "limit_orders" / "HYPEUSDT.json"
+    assert target.exists()
+    assert target.read_text() == "hello"


### PR DESCRIPTION
## Summary
- Ensure `save_text` creates any missing parent directories
- Store limit order metadata under `outputs/limit_orders` and rely on `save_text` for directory creation
- Add unit test verifying `save_text` handles nested paths

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad3664f4308323af1647f6461d4b5c