### PR TITLE
Move stop-loss to entry after TP1 is hit

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,5 @@
 Automated trading bot orchestrator with scheduled checks and order management.
 
 This build automatically removes JSON metadata for cancelled limit orders without open positions.
+
+The stop-loss manager shifts the stop-loss to the entry price once the first take-profit is hit.


### PR DESCRIPTION
## Summary
- Fetch current price alongside open orders to detect TP1 hits
- Reposition stop-loss at the entry price once TP1 is breached
- Note stop-loss adjustment behavior in documentation

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ad6523139c832393d178ec454605c7