### PR TITLE
fix: filter market-cap list to honor limit

### DIFF
--- a/tests/test_exchange_utils.py
+++ b/tests/test_exchange_utils.py
@@ -50,14 +50,40 @@ def test_top_by_market_cap(monkeypatch):
 
     def fake_get(url, params=None, timeout=None):
         calls.append(1)
-        assert params["per_page"] == 2
-        return DummyResponse([{"symbol": "btc"}, {"symbol": "eth"}])
+        expected = min(250, max(2 * 2, 2 + len(exchange_utils.BLACKLIST_BASES)))
+        assert params["per_page"] == expected
+        return DummyResponse(
+            [{"symbol": "btc"}, {"symbol": "eth"}, {"symbol": "xrp"}, {"symbol": "usdt"}]
+        )
 
     monkeypatch.setattr(requests, "get", fake_get)
     exchange_utils._MCAP_CACHE["timestamp"] = 0
     exchange_utils._MCAP_CACHE["data"] = []
     res1 = exchange_utils.top_by_market_cap(2)
     res2 = exchange_utils.top_by_market_cap(2)
-    assert res1 == ["BTC", "ETH"]
-    assert res2 == ["BTC", "ETH"]
+    assert res1 == ["ETH", "XRP"]
+    assert res2 == ["ETH", "XRP"]
     assert len(calls) == 1
+
+
+def test_top_by_market_cap_filters_blacklist(monkeypatch):
+    data = [
+        {"symbol": "usdt"},
+        {"symbol": "btc"},
+        {"symbol": "eth"},
+        {"symbol": "bnb"},
+        {"symbol": "xrp"},
+        {"symbol": "ada"},
+    ]
+
+    class Resp:
+        def json(self):
+            return data
+
+        def raise_for_status(self):
+            return None
+
+    monkeypatch.setattr(requests, "get", lambda *a, **k: Resp())
+    exchange_utils._MCAP_CACHE["data"] = []
+    res = exchange_utils.top_by_market_cap(limit=3, ttl=0)
+    assert res == ["ETH", "XRP", "ADA"]


### PR DESCRIPTION
## Summary
- ensure `top_by_market_cap` filters out blacklisted/stable coins and fetches extra entries
- extend tests to cover blacklist filtering and updated pagination logic

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad82a919008323bbc0521ffb26088e