### PR TITLE
Gracefully handle missing liquidation data

### DIFF
--- a/exchange_utils.py
+++ b/exchange_utils.py
@@ -233,6 +233,13 @@ def liquidation_snapshot(
     exchange: ccxt.Exchange, symbol: str, limit: int = 50
 ) -> Dict:
     """Return recent liquidation statistics for ``symbol``."""
+    # ``fetch_liquidations`` is not implemented for all exchanges.  The
+    # Binance client used by this project, for example, does not support it
+    # which resulted in noisy ``NotSupported`` warnings.  Guard against that
+    # here so we simply return an empty payload when the capability is
+    # missing.
+    if not getattr(exchange, "has", {}).get("fetchLiquidations"):
+        return {}
 
     try:
         rows = exchange.fetch_liquidations(symbol, limit=limit)

--- a/tests/test_exchange_utils.py
+++ b/tests/test_exchange_utils.py
@@ -87,3 +87,14 @@ def test_top_by_market_cap_filters_blacklist(monkeypatch):
     exchange_utils._MCAP_CACHE["data"] = []
     res = exchange_utils.top_by_market_cap(limit=3, ttl=0)
     assert res == ["ETH", "XRP", "ADA"]
+
+
+def test_liquidation_snapshot_unsupported_exchange(caplog):
+    class DummyExchange:
+        has = {"fetchLiquidations": False}
+
+    ex = DummyExchange()
+    with caplog.at_level("WARNING"):
+        res = exchange_utils.liquidation_snapshot(ex, "ETH/USDT:USDT")
+    assert res == {}
+    assert "liquidation_snapshot error" not in caplog.text


### PR DESCRIPTION
## Summary
- avoid calling `fetch_liquidations` on exchanges that don't support it
- add regression test for unsupported liquidation snapshots

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ad8458dac48323abf6b399dabe6453