### PR TITLE
Cache top-volume coins and prioritize daily gainers

### DIFF
--- a/tests/test_build_payload.py
+++ b/tests/test_build_payload.py
@@ -13,7 +13,8 @@ class DummyExchange:
 def test_build_payload_fills_from_market_cap(monkeypatch):
     monkeypatch.setattr(pb, "positions_snapshot", lambda ex: [])
     monkeypatch.setattr(pb, "coin_payload", lambda ex, sym: {"p": pb.norm_pair_symbol(sym)})
-    monkeypatch.setattr(pb, "top_by_qv", lambda ex, lim: ["AAA/USDT:USDT"])
+    monkeypatch.setattr(pb, "cache_top_by_qv", lambda ex, limit=100: ["AAA/USDT:USDT"])
+    monkeypatch.setattr(pb, "top_gainers", lambda ex, limit=10: [])
     monkeypatch.setattr(pb, "top_by_market_cap", lambda lim, ttl=3600: ["AAA", "BBB"])
     monkeypatch.setattr(
         pb,
@@ -34,7 +35,8 @@ def test_build_payload_fills_from_market_cap(monkeypatch):
 def test_build_payload_handles_numeric_prefix(monkeypatch):
     monkeypatch.setattr(pb, "positions_snapshot", lambda ex: [])
     monkeypatch.setattr(pb, "coin_payload", lambda ex, sym: {"p": pb.norm_pair_symbol(sym)})
-    monkeypatch.setattr(pb, "top_by_qv", lambda ex, lim: [])
+    monkeypatch.setattr(pb, "cache_top_by_qv", lambda ex, limit=100: [])
+    monkeypatch.setattr(pb, "top_gainers", lambda ex, limit=10: [])
     monkeypatch.setattr(pb, "top_by_market_cap", lambda lim, ttl=3600: ["PEPE"])
     monkeypatch.setattr(
         pb,
@@ -47,3 +49,39 @@ def test_build_payload_handles_numeric_prefix(monkeypatch):
     pairs = {c["p"] for c in payload["coins"]}
     assert pairs == {"1000PEPEUSDT"}
     assert "time" in payload and "eth" in payload
+
+
+def test_build_payload_prioritizes_gainers_and_skips_positions(monkeypatch):
+    monkeypatch.setattr(
+        pb, "positions_snapshot", lambda ex: [{"pair": "BBBUSDT"}]
+    )
+    monkeypatch.setattr(pb, "coin_payload", lambda ex, sym: {"p": pb.norm_pair_symbol(sym)})
+    monkeypatch.setattr(
+        pb,
+        "cache_top_by_qv",
+        lambda ex, limit=100: [
+            "AAA/USDT:USDT",
+            "BBB/USDT:USDT",
+            "CCC/USDT:USDT",
+        ],
+    )
+    monkeypatch.setattr(
+        pb,
+        "top_gainers",
+        lambda ex, limit=10: ["CCC/USDT:USDT", "BBB/USDT:USDT"],
+    )
+    monkeypatch.setattr(pb, "top_by_market_cap", lambda lim, ttl=3600: ["AAA", "BBB", "CCC"])
+    monkeypatch.setattr(
+        pb,
+        "load_usdtm",
+        lambda ex: {
+            "AAA/USDT:USDT": {"base": "AAA"},
+            "BBB/USDT:USDT": {"base": "BBB"},
+            "CCC/USDT:USDT": {"base": "CCC"},
+        },
+    )
+    monkeypatch.setattr(pb, "_snap_with_cache", lambda *a, **k: {"ema": 0})
+
+    payload = pb.build_payload(DummyExchange(), limit=2)
+    pairs = [c["p"] for c in payload["coins"]]
+    assert pairs == ["CCCUSDT", "AAAUSDT"]


### PR DESCRIPTION
## Summary
- cache and reuse top-volume symbols with numeric-prefix normalization
- add helper to fetch 24h top gainers
- prioritize gainers and fill remaining slots from cached volume list in payload builder

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68ad9b723ce08323b69ffa208618a848