### PR TITLE
Preserve SL/TP metadata for TP1 checks

### DIFF
--- a/futures_gpt_orchestrator_full.py
+++ b/futures_gpt_orchestrator_full.py
@@ -56,6 +56,8 @@ logger = logging.getLogger(__name__)
 
 # Directory inside ``outputs`` where limit order metadata is stored
 LIMIT_ORDER_DIR = Path("outputs") / "limit_orders"
+# Directory to keep details of active positions after SL/TP orders are placed
+ACTIVE_ORDER_DIR = Path("outputs") / "active_orders"
 
 
 def _place_sl_tp(exchange, symbol, side, qty, sl, tp1, tp2, tp3):
@@ -280,9 +282,10 @@ def add_sl_tp_from_json(exchange):
             continue
         _place_sl_tp(exchange, ccxt_sym, side, qty, sl, tp1, tp2, tp3)
         try:
-            fp.unlink()
+            ACTIVE_ORDER_DIR.mkdir(parents=True, exist_ok=True)
+            fp.replace(ACTIVE_ORDER_DIR / fp.name)
         except Exception as e:
-            logger.warning("add_sl_tp_from_json unlink error %s: %s", fp, e)
+            logger.warning("add_sl_tp_from_json move error %s: %s", fp, e)
 
 
 

--- a/tests/test_futures_gpt_orchestrator_full.py
+++ b/tests/test_futures_gpt_orchestrator_full.py
@@ -92,7 +92,11 @@ def test_place_sl_tp(side, exit_side):
 
 
 def test_add_sl_tp_from_json(tmp_path, monkeypatch):
-    monkeypatch.setattr(orch, "LIMIT_ORDER_DIR", tmp_path)
+    limit_dir = tmp_path / "limit"
+    active_dir = tmp_path / "active"
+    limit_dir.mkdir()
+    monkeypatch.setattr(orch, "LIMIT_ORDER_DIR", limit_dir)
+    monkeypatch.setattr(orch, "ACTIVE_ORDER_DIR", active_dir)
     data = {
         "pair": "BTCUSDT",
         "order_id": "1",
@@ -104,10 +108,11 @@ def test_add_sl_tp_from_json(tmp_path, monkeypatch):
         "tp2": 1.2,
         "tp3": 1.3,
     }
-    (tmp_path / "BTCUSDT.json").write_text(json.dumps(data))
+    (limit_dir / "BTCUSDT.json").write_text(json.dumps(data))
     ex = FilledExchange()
     orch.add_sl_tp_from_json(ex)
-    assert not (tmp_path / "BTCUSDT.json").exists()
+    assert not (limit_dir / "BTCUSDT.json").exists()
+    assert (active_dir / "BTCUSDT.json").exists()
     assert ex.orders == [
         ("BTC/USDT", "limit", "sell", 10, 0.9, {"stopPrice": 0.9, "reduceOnly": True}),
         ("BTC/USDT", "limit", "sell", 3.0, 1.1, {"reduceOnly": True}),


### PR DESCRIPTION
## Summary
- Keep SL/TP metadata by moving processed limit-order JSON files into `active_orders`
- Add tests to verify JSON is moved and persists after placing SL/TP orders

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68add510fdd48323b420760bc8f9de56