### PR TITLE
Refine orchestrator for 15m cycle and single take-profit

### DIFF
--- a/payload_builder.py
+++ b/payload_builder.py
@@ -17,7 +17,7 @@ from exchange_utils import (
     fetch_ohlcv_df,
     load_usdtm,
     orderbook_snapshot,
-    top_gainers,
+    cache_top_by_qv,
     top_by_market_cap,
     funding_snapshot,
     open_interest_snapshot,
@@ -194,7 +194,7 @@ def build_payload(
     exclude_pairs = exclude_pairs or set()
     positions = positions_snapshot(exchange)
     pos_pairs = {p.get("pair") for p in positions}
-    gainers = top_gainers(exchange, limit=limit)
+    volumes = cache_top_by_qv(exchange, limit=limit)
     mc_list = top_by_market_cap(max(limit, 200), ttl=mc_ttl)
     mc_bases = set(mc_list)
     markets = load_usdtm(exchange)
@@ -206,7 +206,7 @@ def build_payload(
     symbols: List[str] = []
     used_bases: Set[str] = set()
 
-    for s in gainers:
+    for s in volumes:
         pair = norm_pair_symbol(s)
         base = strip_numeric_prefix(pair[:-4])
         if (

--- a/prompts.py
+++ b/prompts.py
@@ -10,11 +10,10 @@ PROMPT_SYS_MINI = (
 )
 
 PROMPT_USER_MINI = (
-    "Dữ liệu đầy đủ dưới đây (không bỏ sót trường nào). Phân tích như trader chuyên nghiệp, dùng mọi phương pháp: price action & mô hình nến (pinbar, engulfing, doji, breakout...), EMA20/50/200, RSI, MACD, ATR, volume spike, đa khung (1h/H4/D1), ETH bias, orderbook. "
+    "Dữ liệu đầy đủ dưới đây (không bỏ sót trường nào). Phân tích như trader chuyên nghiệp, dùng mọi phương pháp: price action & mô hình nến (pinbar, engulfing, doji, breakout...), EMA20/50/200, RSI, MACD, ATR, volume spike, đa khung (15m/H1/H4), ETH bias, orderbook. "
     "Chỉ chọn lệnh khi conf ≥ 7.0 và RR ≥ 1.8."
-    "Chốt lời theo chuẩn R: TP1 = 1R, TP3 = 2.5R (R = |entry - sl|; với long: TP = entry + k*R; với short: TP = entry - k*R). "
-    "TP2 = mục tiêu chính gần vùng kháng cự/hỗ trợ mạnh, ưu tiên RR≈2.0 (nếu không có vùng rõ ràng, đặt TP2 = entry + 2.0R cho long hoặc entry - 2.0R cho short). "
-    "Trả về JSON duy nhất dạng {\"coins\":[{\"pair\":\"SYMBOL\",\"entry\":0.0,\"sl\":0.0,\"tp1\":0.0,\"tp2\":0.0,\"tp3\":0.0,\"conf\":0.0,\"rr\":0.0}]}; rr là tỷ lệ RR tại TP2 (hoặc tại target chính gần SR), yêu cầu rr ≥ 1.8 "
+    "Chốt lời theo chuẩn R: TP1 = 2R (R = |entry - sl|; với long: TP = entry + k*R; với short: TP = entry - k*R). "
+    "Trả về JSON duy nhất dạng {\"coins\":[{\"pair\":\"SYMBOL\",\"entry\":0.0,\"sl\":0.0,\"tp1\":0.0,\"conf\":0.0,\"rr\":0.0}]}; rr là tỷ lệ RR tại TP1, yêu cầu rr ≥ 1.8 "
     "Không có tín hiệu → {\"coins\":[]}. "
     "DATA:{payload}"
 )

--- a/tests/test_build_payload.py
+++ b/tests/test_build_payload.py
@@ -13,7 +13,7 @@ class DummyExchange:
 def test_build_payload_fills_from_market_cap(monkeypatch):
     monkeypatch.setattr(pb, "positions_snapshot", lambda ex: [])
     monkeypatch.setattr(pb, "coin_payload", lambda ex, sym: {"p": pb.norm_pair_symbol(sym)})
-    monkeypatch.setattr(pb, "top_gainers", lambda ex, limit=10: [])
+    monkeypatch.setattr(pb, "cache_top_by_qv", lambda ex, limit=10: [])
     monkeypatch.setattr(pb, "top_by_market_cap", lambda lim, ttl=3600: ["AAA", "BBB"])
     monkeypatch.setattr(
         pb,
@@ -34,7 +34,7 @@ def test_build_payload_fills_from_market_cap(monkeypatch):
 def test_build_payload_handles_numeric_prefix(monkeypatch):
     monkeypatch.setattr(pb, "positions_snapshot", lambda ex: [])
     monkeypatch.setattr(pb, "coin_payload", lambda ex, sym: {"p": pb.norm_pair_symbol(sym)})
-    monkeypatch.setattr(pb, "top_gainers", lambda ex, limit=10: [])
+    monkeypatch.setattr(pb, "cache_top_by_qv", lambda ex, limit=10: [])
     monkeypatch.setattr(pb, "top_by_market_cap", lambda lim, ttl=3600: ["PEPE"])
     monkeypatch.setattr(
         pb,
@@ -56,7 +56,7 @@ def test_build_payload_prioritizes_gainers_and_skips_positions(monkeypatch):
     monkeypatch.setattr(pb, "coin_payload", lambda ex, sym: {"p": pb.norm_pair_symbol(sym)})
     monkeypatch.setattr(
         pb,
-        "top_gainers",
+        "cache_top_by_qv",
         lambda ex, limit=10: ["CCC/USDT:USDT", "BBB/USDT:USDT"],
     )
     monkeypatch.setattr(pb, "top_by_market_cap", lambda lim, ttl=3600: ["AAA", "BBB", "CCC"])

--- a/tests/test_trading_utils.py
+++ b/tests/test_trading_utils.py
@@ -22,13 +22,13 @@ def test_to_ccxt_symbol_with_exchange_markets():
 def test_parse_mini_actions_handles_close():
     text = (
         "{"
-        '"coins":[{"pair":"BTCUSDT","entry":1,"sl":0.9,"tp1":1.05,"tp2":1.1,"tp3":1.2,"conf":8,"rr":2.5}],'
+        '"coins":[{"pair":"BTCUSDT","entry":1,"sl":0.9,"tp1":1.05,"conf":8,"rr":2.5}],'
         '"close_all":[{"pair":"ETHUSDT"}],'
         '"close_partial":[{"pair":"LTCUSDT","pct":25}]}'
     )
     res = trading_utils.parse_mini_actions(text)
     assert res["coins"] and res["coins"][0]["pair"] == "BTCUSDT"
-    assert res["coins"][0]["tp3"] == 1.2
+    assert res["coins"][0]["tp1"] == 1.05
     assert res["coins"][0]["conf"] == 8.0
     assert res["coins"][0]["rr"] == 2.5
     assert res["close_all"] == [{"pair": "ETHUSDT"}]

--- a/trading_utils.py
+++ b/trading_utils.py
@@ -14,7 +14,7 @@ def parse_mini_actions(text: str) -> Dict[str, List[Dict[str, Any]]]:
     """Parse MINI model JSON output into open/close instructions.
 
     Returns a dict with keys ``coins``, ``close_all`` and ``close_partial``.
-    ``coins`` contains dicts with trading instructions (entry, SL, TP1–TP3, risk).
+    ``coins`` contains dicts with trading instructions (entry, SL, TP1, risk).
     ``close_all`` is a list of {"pair"} dicts. ``close_partial`` is a list of
     {"pair", "pct"} dicts where ``pct`` is a percentage between 0 and 100.
     Invalid entries are ignored silently.
@@ -35,8 +35,6 @@ def parse_mini_actions(text: str) -> Dict[str, List[Dict[str, Any]]]:
         entry = item.get("entry")
         sl = item.get("sl")
         tp1 = item.get("tp1")
-        tp2 = item.get("tp2")
-        tp3 = item.get("tp3")
         risk = item.get("risk")
         conf = item.get("conf")
         rr = item.get("rr")
@@ -44,8 +42,6 @@ def parse_mini_actions(text: str) -> Dict[str, List[Dict[str, Any]]]:
             entry = float(entry) if entry is not None else None
             sl = float(sl) if sl is not None else None
             tp1 = float(tp1) if tp1 not in (None, "") else None
-            tp2 = float(tp2) if tp2 not in (None, "") else None
-            tp3 = float(tp3) if tp3 not in (None, "") else None
             risk = float(risk) if risk not in (None, "") else None
             conf = float(conf) if conf not in (None, "") else None
             rr = float(rr) if rr not in (None, "") else None
@@ -56,22 +52,15 @@ def parse_mini_actions(text: str) -> Dict[str, List[Dict[str, Any]]]:
         if risk is not None and not (0 < risk < 1):
             continue
         side = "buy" if entry > sl else "sell"
-        invalid_tp = False
-        for tp in (tp1, tp2, tp3):
-            if tp is not None:
-                if (side == "buy" and tp <= entry) or (side == "sell" and tp >= entry):
-                    invalid_tp = True
-                    break
-        if invalid_tp:
-            continue
+        if tp1 is not None:
+            if (side == "buy" and tp1 <= entry) or (side == "sell" and tp1 >= entry):
+                continue
         coins.append(
             {
                 "pair": pair,
                 "entry": entry,
                 "sl": sl,
                 "tp1": tp1,
-                "tp2": tp2,
-                "tp3": tp3,
                 "risk": risk,
                 "conf": conf,
                 "rr": rr,
@@ -201,31 +190,21 @@ def infer_side(entry: float, sl: float, tp: Optional[float]) -> Optional[str]:
 
 
 def enrich_tp_qty(exchange, acts: List[Dict[str, Any]], capital: float) -> List[Dict[str, Any]]:
-    """Compute qty and default TP1–TP3 (1R/2R/3R) for each action."""
+    """Compute qty and default TP1 (2R) for each action."""
 
     out: List[Dict[str, Any]] = []
     for a in acts:
         entry = a.get("entry")
         sl = a.get("sl")
         tp1 = a.get("tp1")
-        tp2 = a.get("tp2")
-        tp3 = a.get("tp3")
         risk = a.get("risk")
         if not (isinstance(entry, (int, float)) and isinstance(sl, (int, float))):
             continue
         dist = entry - sl
-        tp1_def = entry + dist
-        tp2_def = entry + 2 * dist
-        tp3_def = entry + 3 * dist
+        tp1_def = entry + 2 * dist
         if not (isinstance(tp1, (int, float)) and tp1 != entry):
             tp1 = tp1_def
-        if not (isinstance(tp2, (int, float)) and tp2 != entry):
-            tp2 = tp2_def
-        if not (isinstance(tp3, (int, float)) and tp3 != entry):
-            tp3 = tp3_def
         a["tp1"] = rfloat(tp1, 8)
-        a["tp2"] = rfloat(tp2, 8)
-        a["tp3"] = rfloat(tp3, 8)
         rf = float(risk) if isinstance(risk, (int, float)) and risk > 0 else 0.01
         ccxt_sym = to_ccxt_symbol(a["pair"])
         step = qty_step(exchange, ccxt_sym)
@@ -241,8 +220,7 @@ def enrich_tp_qty(exchange, acts: List[Dict[str, Any]], capital: float) -> List[
             continue  # bỏ qua nếu khối lượng bằng 0
         a["qty"] = rfloat(qty, 8)
         a["risk"] = rfloat(rf, 6)
-        side_tp = tp3 if tp3 is not None else tp2 if tp2 is not None else tp1
-        side = infer_side(float(entry), float(sl), float(side_tp))
+        side = infer_side(float(entry), float(sl), float(tp1))
         if side in {"buy", "sell"}:
             a["side"] = side
             out.append(a)


### PR DESCRIPTION
## Summary
- Place SL/TP as market close-all orders and drop TP2/TP3
- Run orchestrator every 15m and clean/add orders on 10m/1m intervals
- Build payload using top 24h volume coins and updated prompts/utility logic

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae6067410c8323865135b7073029cd