### PR TITLE
Switch references from 1h to 15m timeframe

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# scalping_1h
+# scalping_15m
 
 Automated trading bot orchestrator with scheduled checks and order management.
 

--- a/backtest.py
+++ b/backtest.py
@@ -65,7 +65,7 @@ def run_backtest(symbol: str, timeframe: str, limit: int, since: int | None) -> 
 def _parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Run a simple backtest")
     parser.add_argument("--symbol", default="BTC/USDT", help="CCXT symbol, e.g. BTC/USDT")
-    parser.add_argument("--timeframe", default="1h", help="Candle timeframe")
+    parser.add_argument("--timeframe", default="15m", help="Candle timeframe")
     parser.add_argument("--limit", type=int, default=500, help="Number of candles to fetch")
     parser.add_argument(
         "--since", type=int, default=None, help="Optional start timestamp in milliseconds"

--- a/bot_deployment_steps.txt
+++ b/bot_deployment_steps.txt
@@ -7,8 +7,8 @@
 
 # 2. UPLOAD BOT MỚI TỪ MÁY LOCAL (trên Git Bash Windows)
 
-#dual 
-scp -i /home/duongminhlong/Downloads/bot-trading.pem "/home/duongminhlong/Downloads/scalping_1h/scalping_1h_deploy.zip" ubuntu@47.130.82.78:~
+#dual
+scp -i /home/duongminhlong/Downloads/bot-trading.pem "/home/duongminhlong/Downloads/scalping_15m/scalping_15m_deploy.zip" ubuntu@47.130.82.78:~
 
 chmod +x deploy_full_dual.sh
 ./deploy_full_dual.sh
@@ -67,7 +67,7 @@ ps aux | grep call_check_position.py
 pkill -f bot_main.py || true
 pkill -f call_check_position.py || true
 # 4. GIẢI NÉN ZIP (nếu không dùng script tự động)
-unzip -o scalping_1h_deploy -d ~/scalping_1h_deploy
+unzip -o scalping_15m_deploy -d ~/scalping_15m_deploy
 
 # add permission
     chmod +x deploy.sh

--- a/deploy.sh
+++ b/deploy.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 step=1
 step() { echo -e "\n[$step] $1"; step=$((step+1)); }
 
-echo "🚀 Starting full deployment for scalping 1h bot..."
+echo "🚀 Starting full deployment for scalping 15m bot..."
 
 step "Ensure python3 and pip are available"
 if ! command -v python3 >/dev/null; then

--- a/futures_gpt_orchestrator_full.py
+++ b/futures_gpt_orchestrator_full.py
@@ -1,4 +1,4 @@
-"""Futures → GPT Orchestrator (1h focus, H4/D1 context; retains ETH bias).
+"""Futures → GPT Orchestrator (15m focus, H4/D1 context; retains ETH bias).
 
 This script orchestrates the flow:
 1. Build payloads from market data

--- a/payload_builder.py
+++ b/payload_builder.py
@@ -1,4 +1,4 @@
-"""Payload construction utilities for 1h trading with higher timeframe snapshots."""
+"""Payload construction utilities for 15m trading with higher timeframe snapshots."""
 
 from __future__ import annotations
 
@@ -30,10 +30,10 @@ from positions import positions_snapshot
 logger = logging.getLogger(__name__)
 
 # Cache for OHLCV data by timeframe
-CACHE_H1: Dict[str, pd.DataFrame] = {}
+CACHE_M15: Dict[str, pd.DataFrame] = {}
 CACHE_H4: Dict[str, pd.DataFrame] = {}
 CACHE_D1: Dict[str, pd.DataFrame] = {}
-LOCK_H1 = Lock()
+LOCK_M15 = Lock()
 LOCK_H4 = Lock()
 LOCK_D1 = Lock()
 
@@ -102,8 +102,8 @@ def strip_numeric_prefix(base: str) -> str:
     return re.sub(r"^\d+", "", base)
 
 
-def build_1h(df: pd.DataFrame, limit: int = 20, nd: int = 5) -> Dict:
-    """Build the detailed 1h payload with indicators and OHLCV."""
+def build_15m(df: pd.DataFrame, limit: int = 20, nd: int = 5) -> Dict:
+    """Build the detailed 15m payload with indicators and OHLCV."""
 
     data = add_indicators(df)
     if limit <= 1:
@@ -159,19 +159,19 @@ def build_snap(df: pd.DataFrame) -> Dict:
 def coin_payload(exchange, symbol: str) -> Dict:
     """Build payload for a single symbol with thread-safe caching."""
 
-    with LOCK_H1:
-        if symbol not in CACHE_H1:
-            CACHE_H1[symbol] = fetch_ohlcv_df(exchange, symbol, "1h", 300)
+    with LOCK_M15:
+        if symbol not in CACHE_M15:
+            CACHE_M15[symbol] = fetch_ohlcv_df(exchange, symbol, "15m", 300)
         else:
-            last_ts = int(CACHE_H1[symbol].index[-1].timestamp() * 1000)
-            new = fetch_ohlcv_df(exchange, symbol, "1h", 300, since=last_ts)
+            last_ts = int(CACHE_M15[symbol].index[-1].timestamp() * 1000)
+            new = fetch_ohlcv_df(exchange, symbol, "15m", 300, since=last_ts)
             if not new.empty:
-                df = pd.concat([CACHE_H1[symbol], new]).sort_index()
-                CACHE_H1[symbol] = df[~df.index.duplicated(keep="last")].tail(300)
-        h1 = CACHE_H1[symbol]
+                df = pd.concat([CACHE_M15[symbol], new]).sort_index()
+                CACHE_M15[symbol] = df[~df.index.duplicated(keep="last")].tail(300)
+        m15 = CACHE_M15[symbol]
     payload = {
         "pair": norm_pair_symbol(symbol),
-        "h1": build_1h(h1),
+        "m15": build_15m(m15),
         "h4": _snap_with_cache(exchange, symbol, "4h", CACHE_H4, LOCK_H4),
         "d1": _snap_with_cache(exchange, symbol, "1d", CACHE_D1, LOCK_D1),
         "funding": funding_snapshot(exchange, symbol),

--- a/tests/test_payload_builder.py
+++ b/tests/test_payload_builder.py
@@ -5,7 +5,7 @@ sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
 import payload_builder  # noqa: E402
 
 
-def test_build_1h_adds_volume(monkeypatch):
+def test_build_15m_adds_volume(monkeypatch):
     import pandas as pd
 
     def fake_add_indicators(df):
@@ -35,14 +35,14 @@ def test_build_1h_adds_volume(monkeypatch):
             "close": [1.05, 2.05],
             "volume": [100.0, 200.0],
         },
-        index=pd.date_range("2024-01-01", periods=2, freq="1h"),
+        index=pd.date_range("2024-01-01", periods=2, freq="15min"),
     )
 
-    res = payload_builder.build_1h(df)
+    res = payload_builder.build_15m(df)
     assert all(len(candle) == 5 for candle in res["ohlcv"])
 
 
-def test_build_1h_volume_numeric(monkeypatch):
+def test_build_15m_volume_numeric(monkeypatch):
     import pandas as pd
 
     def fake_add_indicators(df):
@@ -72,14 +72,14 @@ def test_build_1h_volume_numeric(monkeypatch):
             "close": [1.05, 2.05],
             "volume": [100.0, 312066130.0],
         },
-        index=pd.date_range("2024-01-01", periods=2, freq="1h"),
+        index=pd.date_range("2024-01-01", periods=2, freq="15min"),
     )
 
-    res = payload_builder.build_1h(df)
+    res = payload_builder.build_15m(df)
     assert res["ohlcv"][-1][-1] == "312M"
 
 
-def test_build_1h_limits_length_and_snap(monkeypatch):
+def test_build_15m_limits_length_and_snap(monkeypatch):
     import pandas as pd
 
     def fake_add_indicators(df):
@@ -110,10 +110,10 @@ def test_build_1h_limits_length_and_snap(monkeypatch):
             "close": range(25),
             "volume": range(25),
         },
-        index=pd.date_range("2024-01-01", periods=25, freq="1h"),
+        index=pd.date_range("2024-01-01", periods=25, freq="15min"),
     )
 
-    res = payload_builder.build_1h(df)
+    res = payload_builder.build_15m(df)
     assert len(res["ohlcv"]) == 20
     assert all(len(v) == 20 for v in res["ind"].values())
     assert set(res["ind"].keys()) == {
@@ -129,7 +129,7 @@ def test_build_1h_limits_length_and_snap(monkeypatch):
         "vol_spike",
     }
 
-    snap = payload_builder.build_1h(df, limit=1)
+    snap = payload_builder.build_15m(df, limit=1)
     expected = payload_builder.build_snap(df)
     assert snap == expected
 
@@ -164,7 +164,7 @@ def test_build_snap_rounds_price(monkeypatch):
             "close": [1.05],
             "volume": [100.0],
         },
-        index=pd.date_range("2024-01-01", periods=1, freq="1h"),
+        index=pd.date_range("2024-01-01", periods=1, freq="15min"),
     )
 
     snap = payload_builder.build_snap(df)
@@ -174,7 +174,7 @@ def test_build_snap_rounds_price(monkeypatch):
 def test_coin_payload_includes_higher_timeframes(monkeypatch):
     import pandas as pd
 
-    payload_builder.CACHE_H1.clear()
+    payload_builder.CACHE_M15.clear()
     payload_builder.CACHE_H4.clear()
     payload_builder.CACHE_D1.clear()
 
@@ -187,7 +187,7 @@ def test_coin_payload_includes_higher_timeframes(monkeypatch):
                 "close": [1.0],
                 "volume": [1.0],
             },
-            index=pd.date_range("2024-01-01", periods=1, freq="1h", tz="UTC"),
+            index=pd.date_range("2024-01-01", periods=1, freq="15min", tz="UTC"),
         )
 
     def fake_add_indicators(df):
@@ -219,7 +219,7 @@ def test_coin_payload_includes_higher_timeframes(monkeypatch):
     res = payload_builder.coin_payload(None, "BTC/USDT:USDT")
     assert {
         "pair",
-        "h1",
+        "m15",
         "h4",
         "d1",
         "funding",


### PR DESCRIPTION
## Summary
- Update docs and deployment scripts to reference 15m scalping bot
- Replace payload builder 1h utilities with 15m versions and adjust orchestrator
- Refresh tests and backtest defaults for 15m timeframe

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ae67d176788323932c546757897cc4