### PR TITLE
Use 1h timeframe snapshots in payloads

### DIFF
--- a/payload_builder.py
+++ b/payload_builder.py
@@ -31,11 +31,11 @@ logger = logging.getLogger(__name__)
 
 # Cache for OHLCV data by timeframe
 CACHE_M15: Dict[str, pd.DataFrame] = {}
+CACHE_H1: Dict[str, pd.DataFrame] = {}
 CACHE_H4: Dict[str, pd.DataFrame] = {}
-CACHE_D1: Dict[str, pd.DataFrame] = {}
 LOCK_M15 = Lock()
+LOCK_H1 = Lock()
 LOCK_H4 = Lock()
-LOCK_D1 = Lock()
 
 
 def _snap_with_cache(exchange, symbol: str, timeframe: str, cache, lock) -> Dict:
@@ -172,8 +172,8 @@ def coin_payload(exchange, symbol: str) -> Dict:
     payload = {
         "pair": norm_pair_symbol(symbol),
         "m15": build_15m(m15),
+        "h1": _snap_with_cache(exchange, symbol, "1h", CACHE_H1, LOCK_H1),
         "h4": _snap_with_cache(exchange, symbol, "4h", CACHE_H4, LOCK_H4),
-        "d1": _snap_with_cache(exchange, symbol, "1d", CACHE_D1, LOCK_D1),
         "funding": funding_snapshot(exchange, symbol),
         "oi": open_interest_snapshot(exchange, symbol),
         "cvd": cvd_snapshot(exchange, symbol),
@@ -246,8 +246,8 @@ def build_payload(
                 logger.warning("coin_payload failed for %s: %s", sym, e)
     eth_symbol = pair_to_symbol("ETHUSDT")
     eth = {
+        "h1": _snap_with_cache(exchange, eth_symbol, "1h", CACHE_H1, LOCK_H1),
         "h4": _snap_with_cache(exchange, eth_symbol, "4h", CACHE_H4, LOCK_H4),
-        "d1": _snap_with_cache(exchange, eth_symbol, "1d", CACHE_D1, LOCK_D1),
     }
     return drop_empty(
         {

--- a/tests/test_payload_builder.py
+++ b/tests/test_payload_builder.py
@@ -175,8 +175,8 @@ def test_coin_payload_includes_higher_timeframes(monkeypatch):
     import pandas as pd
 
     payload_builder.CACHE_M15.clear()
+    payload_builder.CACHE_H1.clear()
     payload_builder.CACHE_H4.clear()
-    payload_builder.CACHE_D1.clear()
 
     def fake_fetch(exchange, symbol, timeframe, limit, since=None):
         return pd.DataFrame(
@@ -220,8 +220,8 @@ def test_coin_payload_includes_higher_timeframes(monkeypatch):
     assert {
         "pair",
         "m15",
+        "h1",
         "h4",
-        "d1",
         "funding",
         "oi",
         "cvd",


### PR DESCRIPTION
## Summary
- replace daily snapshot with 1h in payload builder
- update ETH and coin payloads to include 1h and 4h frames
- adapt unit test expectations for new timeframe

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae691fc62c832396162d58caf095ee