### PR TITLE
Fix Binance reduceOnly error

### DIFF
--- a/futures_gpt_orchestrator_full.py
+++ b/futures_gpt_orchestrator_full.py
@@ -62,7 +62,7 @@ def _place_sl_tp(exchange, symbol, side, qty, sl, tp1):
     """Place stop-loss and single take-profit orders as close-all market."""
 
     exit_side = "sell" if side == "buy" else "buy"
-    params = {"reduceOnly": True, "closePosition": True}
+    params = {"closePosition": True}
 
     exchange.create_order(
         symbol,
@@ -383,7 +383,7 @@ def move_sl_to_entry(exchange):
                 exit_side,
                 None,
                 None,
-                {"reduceOnly": True, "closePosition": True, "stopPrice": entry},
+                {"closePosition": True, "stopPrice": entry},
             )
         except Exception as e:
             logger.warning("move_sl_to_entry create_order error for %s: %s", pair, e)

--- a/tests/test_futures_gpt_orchestrator_full.py
+++ b/tests/test_futures_gpt_orchestrator_full.py
@@ -90,7 +90,7 @@ def test_place_sl_tp(side, exit_side):
             exit_side,
             None,
             None,
-            {"stopPrice": 1, "reduceOnly": True, "closePosition": True},
+            {"stopPrice": 1, "closePosition": True},
         ),
         (
             "BTC/USDT",
@@ -98,7 +98,7 @@ def test_place_sl_tp(side, exit_side):
             exit_side,
             None,
             None,
-            {"stopPrice": 2, "reduceOnly": True, "closePosition": True},
+            {"stopPrice": 2, "closePosition": True},
         ),
     ]
 
@@ -127,7 +127,7 @@ def test_add_sl_tp_from_json(tmp_path, monkeypatch):
             "sell",
             None,
             None,
-            {"stopPrice": 0.9, "reduceOnly": True, "closePosition": True},
+            {"stopPrice": 0.9, "closePosition": True},
         ),
         (
             "BTC/USDT",
@@ -135,7 +135,7 @@ def test_add_sl_tp_from_json(tmp_path, monkeypatch):
             "sell",
             None,
             None,
-            {"stopPrice": 1.1, "reduceOnly": True, "closePosition": True},
+            {"stopPrice": 1.1, "closePosition": True},
         ),
     ]
 
@@ -176,7 +176,7 @@ def test_move_sl_to_entry(monkeypatch):
             "sell",
             None,
             None,
-            {"stopPrice": 100, "reduceOnly": True, "closePosition": True},
+            {"stopPrice": 100, "closePosition": True},
         )
     ]
 


### PR DESCRIPTION
## Summary
- remove `reduceOnly` flag from close-position SL/TP orders to satisfy Binance API
- update break-even handling and tests accordingly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68ae6db1a5888323b9bff7944cc5738c