### PR TITLE
Fix SL/TP orders triggering immediately

### DIFF
--- a/futures_gpt_orchestrator_full.py
+++ b/futures_gpt_orchestrator_full.py
@@ -86,7 +86,7 @@ def _place_sl_tp(exchange, symbol, side, qty, sl, tp1):
     try:
         exchange.create_order(
             symbol,
-            "market",
+            "STOP_MARKET",
             exit_side,
             None,
             None,
@@ -94,7 +94,7 @@ def _place_sl_tp(exchange, symbol, side, qty, sl, tp1):
         )
         exchange.create_order(
             symbol,
-            "market",
+            "TAKE_PROFIT_MARKET",
             exit_side,
             None,
             None,
@@ -406,7 +406,7 @@ def move_sl_to_entry(exchange):
         try:
             exchange.create_order(
                 symbol,
-                "market",
+                "STOP_MARKET",
                 exit_side,
                 None,
                 None,

--- a/tests/test_futures_gpt_orchestrator_full.py
+++ b/tests/test_futures_gpt_orchestrator_full.py
@@ -94,7 +94,7 @@ def test_place_sl_tp(side, exit_side):
     assert ex.orders == [
         (
             "BTC/USDT",
-            "market",
+            "STOP_MARKET",
             exit_side,
             None,
             None,
@@ -102,7 +102,7 @@ def test_place_sl_tp(side, exit_side):
         ),
         (
             "BTC/USDT",
-            "market",
+            "TAKE_PROFIT_MARKET",
             exit_side,
             None,
             None,
@@ -143,7 +143,7 @@ def test_add_sl_tp_from_json(tmp_path, monkeypatch):
     assert ex.orders == [
         (
             "BTC/USDT",
-            "market",
+            "STOP_MARKET",
             "sell",
             None,
             None,
@@ -151,7 +151,7 @@ def test_add_sl_tp_from_json(tmp_path, monkeypatch):
         ),
         (
             "BTC/USDT",
-            "market",
+            "TAKE_PROFIT_MARKET",
             "sell",
             None,
             None,
@@ -192,7 +192,7 @@ def test_move_sl_to_entry(monkeypatch):
     assert ex.orders == [
         (
             "BTC/USDT",
-            "market",
+            "STOP_MARKET",
             "sell",
             None,
             None,


### PR DESCRIPTION
## Summary
- use Binance STOP_MARKET and TAKE_PROFIT_MARKET types when placing SL/TP orders
- update break-even stop logic to use STOP_MARKET
- adjust tests for new order types

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae7d77fd748323ade7e47697d680bd