### PR TITLE
Support two take-profit targets

### DIFF
--- a/tests/test_trading_utils.py
+++ b/tests/test_trading_utils.py
@@ -22,13 +22,14 @@ def test_to_ccxt_symbol_with_exchange_markets():
 def test_parse_mini_actions_handles_close():
     text = (
         "{"
-        '"coins":[{"pair":"BTCUSDT","entry":1,"sl":0.9,"tp1":1.05,"conf":8,"rr":2.5}],'
+        '"coins":[{"pair":"BTCUSDT","entry":1,"sl":0.9,"tp1":1.05,"tp2":1.1,"conf":8,"rr":2.5}],'
         '"close_all":[{"pair":"ETHUSDT"}],'
         '"close_partial":[{"pair":"LTCUSDT","pct":25}]}'
     )
     res = trading_utils.parse_mini_actions(text)
     assert res["coins"] and res["coins"][0]["pair"] == "BTCUSDT"
     assert res["coins"][0]["tp1"] == 1.05
+    assert res["coins"][0]["tp2"] == 1.1
     assert res["coins"][0]["conf"] == 8.0
     assert res["coins"][0]["rr"] == 2.5
     assert res["close_all"] == [{"pair": "ETHUSDT"}]


### PR DESCRIPTION
## Summary
- calculate default TP1 and TP2 levels from entry and stop distance
- place partial take-profit orders at 1R and 1.5R
- persist second take-profit value in order metadata

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68afb84097f08323942e192f1dc5e045