### PR TITLE
Clean unmapped limit metadata before GPT call

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,6 @@
 
 Automated trading bot orchestrator with scheduled checks and order management.
 
-This build automatically removes JSON metadata for cancelled limit orders without open positions.
+This build automatically removes JSON metadata for cancelled or unmapped limit orders without open positions before calling the GPT API.
 
 The stop-loss manager shifts the stop-loss to the entry price once the first take-profit is hit.


### PR DESCRIPTION
## Summary
- remove JSON files for limit orders lacking an open order or position
- run cleanup before building payload to keep metadata in sync
- document behavior and add tests for orphaned limit files

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68afb99c3f6c8323b7ede5c92f9b9b63