### PR TITLE
Support two take-profit targets

### DIFF
--- a/futures_gpt_orchestrator_full.py
+++ b/futures_gpt_orchestrator_full.py
@@ -91,11 +91,11 @@ def cancel_all_orders_for_pair(exchange, symbol: str, pair: str) -> None:
         logger.warning("cancel_all_orders_for_pair unlink error %s: %s", fp, e)
 
 
-def _place_sl_tp(exchange, symbol, side, qty, sl, tp1):
-    """Place stop-loss and single take-profit orders as close-all market."""
+def _place_sl_tp(exchange, symbol, side, qty, sl, tp, tp1, tp2):
+    """Place stop-loss and three take-profit orders for partial closes."""
 
     exit_side = "sell" if side == "buy" else "buy"
-    params = {"closePosition": True}
+    params_close = {"closePosition": True}
 
     # To avoid hitting Binance's max stop order limit, cancel any existing
     # close-position stop orders before placing new ones.
@@ -107,7 +107,7 @@ def _place_sl_tp(exchange, symbol, side, qty, sl, tp1):
     for o in orders or []:
         try:
             info = o.get("info") or {}
-            if info.get("closePosition"):
+            if info.get("closePosition") or info.get("reduceOnly"):
                 exchange.cancel_order(o.get("id"), symbol)
         except Exception as e:  # pragma: no cover - cancel may fail
             logger.warning("_place_sl_tp cancel_order error for %s: %s", symbol, e)
@@ -119,15 +119,31 @@ def _place_sl_tp(exchange, symbol, side, qty, sl, tp1):
             exit_side,
             None,
             None,
-            {**params, "stopPrice": sl},
+            {**params_close, "stopPrice": sl},
         )
         exchange.create_order(
             symbol,
             "TAKE_PROFIT_MARKET",
             exit_side,
+            qty * 0.2,
             None,
+            {"stopPrice": tp1, "reduceOnly": True},
+        )
+        exchange.create_order(
+            symbol,
+            "TAKE_PROFIT_MARKET",
+            exit_side,
+            qty * 0.3,
             None,
-            {**params, "stopPrice": tp1},
+            {"stopPrice": tp2, "reduceOnly": True},
+        )
+        exchange.create_order(
+            symbol,
+            "TAKE_PROFIT_MARKET",
+            exit_side,
+            qty * 0.5,
+            None,
+            {"stopPrice": tp, "reduceOnly": True},
         )
     except OperationRejected as e:  # pragma: no cover - depends on exchange state
         if getattr(e, "code", None) == -4045 or "max stop order" in str(e).lower():
@@ -205,7 +221,9 @@ def run(run_live: bool = False, limit: int = 30, ex=None) -> Dict[str, Any]:
             side = c.get("side")
             entry = c.get("entry")
             sl = c.get("sl")
+            tp = c.get("tp")
             tp1 = c.get("tp1")
+            tp2 = c.get("tp2")
             qty = c.get("qty")
             if side not in ("buy", "sell") or pair in pos_pairs_live:
                 continue
@@ -224,7 +242,9 @@ def run(run_live: bool = False, limit: int = 30, ex=None) -> Dict[str, Any]:
                         "limit": entry,
                         "qty": qty,
                         "sl": sl,
+                        "tp": tp,
                         "tp1": tp1,
+                        "tp2": tp2,
                     }
                 ),
                 folder=str(LIMIT_ORDER_DIR),
@@ -235,7 +255,9 @@ def run(run_live: bool = False, limit: int = 30, ex=None) -> Dict[str, Any]:
                     "side": side,
                     "entry": entry,
                     "sl": sl,
+                    "tp": tp,
                     "tp1": tp1,
+                    "tp2": tp2,
                     "qty": qty,
                     "entry_id": entry_order.get("id"),
                 }
@@ -317,8 +339,10 @@ def add_sl_tp_from_json(exchange):
         side = data.get("side")
         qty = data.get("qty")
         sl = data.get("sl")
+        tp = data.get("tp")
         tp1 = data.get("tp1")
-        if not (pair and order_id and side and qty and sl and tp1):
+        tp2 = data.get("tp2")
+        if not (pair and order_id and side and qty and sl and tp and tp1 and tp2):
             continue
         ccxt_sym = to_ccxt_symbol(pair)
         try:
@@ -329,7 +353,7 @@ def add_sl_tp_from_json(exchange):
         status = (o.get("status") or "").lower()
         if status != "closed":
             continue
-        _place_sl_tp(exchange, ccxt_sym, side, qty, sl, tp1)
+        _place_sl_tp(exchange, ccxt_sym, side, qty, sl, tp, tp1, tp2)
         try:
             fp.unlink()
         except Exception as e:

--- a/prompts.py
+++ b/prompts.py
@@ -25,7 +25,7 @@ PROMPT_USER_MINI = (
     "- Session filter: Asia yêu cầu conf ≥ 0.8, US yêu cầu conf ≥ 0.7. Nếu mins_to_close ≤ 15 và tín hiệu yếu → bỏ. "
     "- Entry rule: Ưu tiên LIMIT pullback về EMA20/key level; nếu tín hiệu nến (pinbar/engulfing/doji/breakout) → đặt LIMIT tại 50% thân nến, không đuổi breakout nến 2–3. "
 
-    "Trả về JSON duy nhất dạng {\"coins\":[{\"pair\":\"SYMBOL\",\"entry\":0.0,\"sl\":0.0,\"tp1\":0.0,\"conf\":0.0}]}. "
+    "Trả về JSON duy nhất dạng {\"coins\":[{\"pair\":\"SYMBOL\",\"entry\":0.0,\"sl\":0.0,\"tp\":0.0,\"conf\":0.0}]}. "
     "Không có tín hiệu hợp lệ → {\"coins\":[]}. "
 
     "DATA:{payload}"

--- a/tests/test_futures_gpt_orchestrator_full.py
+++ b/tests/test_futures_gpt_orchestrator_full.py
@@ -123,7 +123,9 @@ def test_run_cancels_existing_orders(monkeypatch, tmp_path):
                     "side": "buy",
                     "entry": 1,
                     "sl": 0.9,
+                    "tp": 1.3,
                     "tp1": 1.1,
+                    "tp2": 1.2,
                     "qty": 1,
                 }
             ]
@@ -145,7 +147,7 @@ def test_run_cancels_existing_orders(monkeypatch, tmp_path):
 @pytest.mark.parametrize("side,exit_side", [("buy", "sell"), ("sell", "buy")])
 def test_place_sl_tp(side, exit_side):
     ex = CaptureExchange()
-    orch._place_sl_tp(ex, "BTC/USDT", side, 10, 1, 2)
+    orch._place_sl_tp(ex, "BTC/USDT", side, 10, 1, 4, 2, 3)
     assert ex.cancelled == []
     assert ex.orders == [
         (
@@ -160,9 +162,25 @@ def test_place_sl_tp(side, exit_side):
             "BTC/USDT",
             "TAKE_PROFIT_MARKET",
             exit_side,
+            2.0,
             None,
+            {"stopPrice": 2, "reduceOnly": True},
+        ),
+        (
+            "BTC/USDT",
+            "TAKE_PROFIT_MARKET",
+            exit_side,
+            3.0,
             None,
-            {"stopPrice": 2, "closePosition": True},
+            {"stopPrice": 3, "reduceOnly": True},
+        ),
+        (
+            "BTC/USDT",
+            "TAKE_PROFIT_MARKET",
+            exit_side,
+            5.0,
+            None,
+            {"stopPrice": 4, "reduceOnly": True},
         ),
     ]
 
@@ -174,9 +192,9 @@ class ExistingStopExchange(CaptureExchange):
 
 def test_place_sl_tp_cancels_existing():
     ex = ExistingStopExchange()
-    orch._place_sl_tp(ex, "BTC/USDT", "buy", 10, 1, 2)
+    orch._place_sl_tp(ex, "BTC/USDT", "buy", 10, 1, 4, 2, 3)
     assert ex.cancelled == [("old1", "BTC/USDT")]
-    assert len(ex.orders) == 2
+    assert len(ex.orders) == 4
 
 
 def test_add_sl_tp_from_json(tmp_path, monkeypatch):
@@ -190,7 +208,9 @@ def test_add_sl_tp_from_json(tmp_path, monkeypatch):
         "limit": 1,
         "qty": 10,
         "sl": 0.9,
+        "tp": 1.3,
         "tp1": 1.1,
+        "tp2": 1.2,
     }
     (limit_dir / "BTCUSDT.json").write_text(json.dumps(data))
     ex = FilledExchange()
@@ -209,9 +229,25 @@ def test_add_sl_tp_from_json(tmp_path, monkeypatch):
             "BTC/USDT",
             "TAKE_PROFIT_MARKET",
             "sell",
+            2.0,
             None,
+            {"stopPrice": 1.1, "reduceOnly": True},
+        ),
+        (
+            "BTC/USDT",
+            "TAKE_PROFIT_MARKET",
+            "sell",
+            3.0,
             None,
-            {"stopPrice": 1.1, "closePosition": True},
+            {"stopPrice": 1.2, "reduceOnly": True},
+        ),
+        (
+            "BTC/USDT",
+            "TAKE_PROFIT_MARKET",
+            "sell",
+            5.0,
+            None,
+            {"stopPrice": 1.3, "reduceOnly": True},
         ),
     ]
 

--- a/tests/test_trading_utils.py
+++ b/tests/test_trading_utils.py
@@ -22,13 +22,13 @@ def test_to_ccxt_symbol_with_exchange_markets():
 def test_parse_mini_actions_handles_close():
     text = (
         "{"
-        '"coins":[{"pair":"BTCUSDT","entry":1,"sl":0.9,"tp1":1.05,"conf":8,"rr":2.5}],'
+        '"coins":[{"pair":"BTCUSDT","entry":1,"sl":0.9,"tp":1.1,"conf":8,"rr":2.5}],'
         '"close_all":[{"pair":"ETHUSDT"}],'
         '"close_partial":[{"pair":"LTCUSDT","pct":25}]}'
     )
     res = trading_utils.parse_mini_actions(text)
     assert res["coins"] and res["coins"][0]["pair"] == "BTCUSDT"
-    assert res["coins"][0]["tp1"] == 1.05
+    assert res["coins"][0]["tp"] == 1.1
     assert res["coins"][0]["conf"] == 8.0
     assert res["coins"][0]["rr"] == 2.5
     assert res["close_all"] == [{"pair": "ETHUSDT"}]

--- a/trading_utils.py
+++ b/trading_utils.py
@@ -14,7 +14,8 @@ def parse_mini_actions(text: str) -> Dict[str, List[Dict[str, Any]]]:
     """Parse MINI model JSON output into open/close instructions.
 
     Returns a dict with keys ``coins``, ``close_all`` and ``close_partial``.
-    ``coins`` contains dicts with trading instructions (entry, SL, TP1, risk).
+    ``coins`` contains dicts with trading instructions (entry, SL, TP,
+    optional TP1/TP2, risk).
     ``close_all`` is a list of {"pair"} dicts. ``close_partial`` is a list of
     {"pair", "pct"} dicts where ``pct`` is a percentage between 0 and 100.
     Invalid entries are ignored silently.
@@ -34,14 +35,18 @@ def parse_mini_actions(text: str) -> Dict[str, List[Dict[str, Any]]]:
             continue
         entry = item.get("entry")
         sl = item.get("sl")
+        tp = item.get("tp")
         tp1 = item.get("tp1")
+        tp2 = item.get("tp2")
         risk = item.get("risk")
         conf = item.get("conf")
         rr = item.get("rr")
         try:
             entry = float(entry) if entry is not None else None
             sl = float(sl) if sl is not None else None
+            tp = float(tp) if tp not in (None, "") else None
             tp1 = float(tp1) if tp1 not in (None, "") else None
+            tp2 = float(tp2) if tp2 not in (None, "") else None
             risk = float(risk) if risk not in (None, "") else None
             conf = float(conf) if conf not in (None, "") else None
             rr = float(rr) if rr not in (None, "") else None
@@ -52,15 +57,29 @@ def parse_mini_actions(text: str) -> Dict[str, List[Dict[str, Any]]]:
         if risk is not None and not (0 < risk < 1):
             continue
         side = "buy" if entry > sl else "sell"
-        if tp1 is not None:
-            if (side == "buy" and tp1 <= entry) or (side == "sell" and tp1 >= entry):
-                continue
+        if tp is not None and (
+            (side == "buy" and tp <= entry)
+            or (side == "sell" and tp >= entry)
+        ):
+            continue
+        if tp1 is not None and (
+            (side == "buy" and tp1 <= entry)
+            or (side == "sell" and tp1 >= entry)
+        ):
+            continue
+        if tp2 is not None and (
+            (side == "buy" and tp2 <= entry)
+            or (side == "sell" and tp2 >= entry)
+        ):
+            continue
         coins.append(
             {
                 "pair": pair,
                 "entry": entry,
                 "sl": sl,
+                "tp": tp,
                 "tp1": tp1,
+                "tp2": tp2,
                 "risk": risk,
                 "conf": conf,
                 "rr": rr,
@@ -190,21 +209,29 @@ def infer_side(entry: float, sl: float, tp: Optional[float]) -> Optional[str]:
 
 
 def enrich_tp_qty(exchange, acts: List[Dict[str, Any]], capital: float) -> List[Dict[str, Any]]:
-    """Compute qty and default TP1 (2R) for each action."""
+    """Compute qty and default TP1/TP2 for each action."""
 
     out: List[Dict[str, Any]] = []
     for a in acts:
         entry = a.get("entry")
         sl = a.get("sl")
+        tp = a.get("tp")
         tp1 = a.get("tp1")
+        tp2 = a.get("tp2")
         risk = a.get("risk")
         if not (isinstance(entry, (int, float)) and isinstance(sl, (int, float))):
             continue
         dist = entry - sl
-        tp1_def = entry + 2 * dist
+        tp1_def = entry + dist
+        tp2_def = entry + 1.5 * dist
         if not (isinstance(tp1, (int, float)) and tp1 != entry):
             tp1 = tp1_def
+        if not (isinstance(tp2, (int, float)) and tp2 != entry):
+            tp2 = tp2_def
         a["tp1"] = rfloat(tp1, 8)
+        a["tp2"] = rfloat(tp2, 8)
+        if isinstance(tp, (int, float)) and tp != entry:
+            a["tp"] = rfloat(tp, 8)
         rf = float(risk) if isinstance(risk, (int, float)) and risk > 0 else 0.01
         ccxt_sym = to_ccxt_symbol(a["pair"])
         step = qty_step(exchange, ccxt_sym)
@@ -220,7 +247,7 @@ def enrich_tp_qty(exchange, acts: List[Dict[str, Any]], capital: float) -> List[
             continue  # bỏ qua nếu khối lượng bằng 0
         a["qty"] = rfloat(qty, 8)
         a["risk"] = rfloat(rf, 6)
-        side = infer_side(float(entry), float(sl), float(tp1))
+        side = infer_side(float(entry), float(sl), float(tp) if tp is not None else None)
         if side in {"buy", "sell"}:
             a["side"] = side
             out.append(a)


### PR DESCRIPTION
## Summary
- preserve GPT-provided tp while computing default tp1 and tp2
- place stop-loss plus partial take profits at 1R (20%), 1.5R (30%) and final tp
- request tp only in prompts and persist tp in order metadata

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68afb84097f08323942e192f1dc5e045