### PR TITLE
Add tp3 support with default tp calculations

### DIFF
--- a/tests/test_futures_gpt_orchestrator_full.py
+++ b/tests/test_futures_gpt_orchestrator_full.py
@@ -125,6 +125,7 @@ def test_run_cancels_existing_orders(monkeypatch, tmp_path):
                     "sl": 0.9,
                     "tp1": 1.1,
                     "tp2": 1.2,
+                    "tp3": 1.3,
                     "qty": 1,
                 }
             ]
@@ -146,7 +147,7 @@ def test_run_cancels_existing_orders(monkeypatch, tmp_path):
 @pytest.mark.parametrize("side,exit_side", [("buy", "sell"), ("sell", "buy")])
 def test_place_sl_tp(side, exit_side):
     ex = CaptureExchange()
-    orch._place_sl_tp(ex, "BTC/USDT", side, 10, 1, 2, 3)
+    orch._place_sl_tp(ex, "BTC/USDT", side, 10, 1, 2, 3, 4)
     assert ex.cancelled == []
     assert ex.orders == [
         (
@@ -159,19 +160,27 @@ def test_place_sl_tp(side, exit_side):
         ),
         (
             "BTC/USDT",
-            "TAKE_PROFIT_MARKET",
+            "TAKE_PROFIT",
             exit_side,
             2.0,
-            None,
+            2,
             {"stopPrice": 2, "reduceOnly": True},
+        ),
+        (
+            "BTC/USDT",
+            "TAKE_PROFIT",
+            exit_side,
+            3.0,
+            3,
+            {"stopPrice": 3, "reduceOnly": True},
         ),
         (
             "BTC/USDT",
             "TAKE_PROFIT_MARKET",
             exit_side,
-            3.0,
+            5.0,
             None,
-            {"stopPrice": 3, "reduceOnly": True},
+            {"stopPrice": 4, "reduceOnly": True},
         ),
     ]
 
@@ -183,9 +192,9 @@ class ExistingStopExchange(CaptureExchange):
 
 def test_place_sl_tp_cancels_existing():
     ex = ExistingStopExchange()
-    orch._place_sl_tp(ex, "BTC/USDT", "buy", 10, 1, 2, 3)
+    orch._place_sl_tp(ex, "BTC/USDT", "buy", 10, 1, 2, 3, 4)
     assert ex.cancelled == [("old1", "BTC/USDT")]
-    assert len(ex.orders) == 3
+    assert len(ex.orders) == 4
 
 
 def test_add_sl_tp_from_json(tmp_path, monkeypatch):
@@ -201,6 +210,7 @@ def test_add_sl_tp_from_json(tmp_path, monkeypatch):
         "sl": 0.9,
         "tp1": 1.1,
         "tp2": 1.2,
+        "tp3": 1.3,
     }
     (limit_dir / "BTCUSDT.json").write_text(json.dumps(data))
     ex = FilledExchange()
@@ -217,19 +227,27 @@ def test_add_sl_tp_from_json(tmp_path, monkeypatch):
         ),
         (
             "BTC/USDT",
-            "TAKE_PROFIT_MARKET",
+            "TAKE_PROFIT",
             "sell",
             2.0,
-            None,
+            1.1,
             {"stopPrice": 1.1, "reduceOnly": True},
+        ),
+        (
+            "BTC/USDT",
+            "TAKE_PROFIT",
+            "sell",
+            3.0,
+            1.2,
+            {"stopPrice": 1.2, "reduceOnly": True},
         ),
         (
             "BTC/USDT",
             "TAKE_PROFIT_MARKET",
             "sell",
-            3.0,
+            5.0,
             None,
-            {"stopPrice": 1.2, "reduceOnly": True},
+            {"stopPrice": 1.3, "reduceOnly": True},
         ),
     ]
 

--- a/tests/test_trading_utils.py
+++ b/tests/test_trading_utils.py
@@ -22,7 +22,7 @@ def test_to_ccxt_symbol_with_exchange_markets():
 def test_parse_mini_actions_handles_close():
     text = (
         "{"
-        '"coins":[{"pair":"BTCUSDT","entry":1,"sl":0.9,"tp1":1.05,"tp2":1.1,"conf":8,"rr":2.5}],'
+        '"coins":[{"pair":"BTCUSDT","entry":1,"sl":0.9,"tp1":1.05,"tp2":1.1,"tp3":1.2,"conf":8,"rr":2.5}],'
         '"close_all":[{"pair":"ETHUSDT"}],'
         '"close_partial":[{"pair":"LTCUSDT","pct":25}]}'
     )
@@ -30,7 +30,26 @@ def test_parse_mini_actions_handles_close():
     assert res["coins"] and res["coins"][0]["pair"] == "BTCUSDT"
     assert res["coins"][0]["tp1"] == 1.05
     assert res["coins"][0]["tp2"] == 1.1
+    assert res["coins"][0]["tp3"] == 1.2
     assert res["coins"][0]["conf"] == 8.0
     assert res["coins"][0]["rr"] == 2.5
     assert res["close_all"] == [{"pair": "ETHUSDT"}]
     assert res["close_partial"] == [{"pair": "LTCUSDT", "pct": 25.0}]
+
+
+def test_enrich_tp_qty_defaults(monkeypatch):
+    ex = types.SimpleNamespace(
+        market=lambda symbol: {"limits": {"leverage": {"max": 100}}, "contractSize": 1}
+    )
+    monkeypatch.setattr(trading_utils, "qty_step", lambda e, s: 1)
+    monkeypatch.setattr(
+        trading_utils,
+        "calc_qty",
+        lambda capital, rf, entry, sl, step, max_lev, contract: 1,
+    )
+    monkeypatch.setattr(trading_utils, "infer_side", lambda entry, sl, tp1: "buy")
+    acts = [{"pair": "BTCUSDT", "entry": 100, "sl": 90, "tp3": 150}]
+    res = trading_utils.enrich_tp_qty(ex, acts, capital=1000)
+    assert res[0]["tp1"] == 110
+    assert res[0]["tp2"] == 110
+    assert res[0]["tp3"] == 150

--- a/trading_utils.py
+++ b/trading_utils.py
@@ -37,6 +37,7 @@ def parse_mini_actions(text: str) -> Dict[str, List[Dict[str, Any]]]:
         sl = item.get("sl")
         tp1 = item.get("tp1")
         tp2 = item.get("tp2")
+        tp3 = item.get("tp3")
         risk = item.get("risk")
         conf = item.get("conf")
         rr = item.get("rr")
@@ -45,6 +46,7 @@ def parse_mini_actions(text: str) -> Dict[str, List[Dict[str, Any]]]:
             sl = float(sl) if sl is not None else None
             tp1 = float(tp1) if tp1 not in (None, "") else None
             tp2 = float(tp2) if tp2 not in (None, "") else None
+            tp3 = float(tp3) if tp3 not in (None, "") else None
             risk = float(risk) if risk not in (None, "") else None
             conf = float(conf) if conf not in (None, "") else None
             rr = float(rr) if rr not in (None, "") else None
@@ -65,6 +67,11 @@ def parse_mini_actions(text: str) -> Dict[str, List[Dict[str, Any]]]:
             or (side == "sell" and tp2 >= entry)
         ):
             continue
+        if tp3 is not None and (
+            (side == "buy" and tp3 <= entry)
+            or (side == "sell" and tp3 >= entry)
+        ):
+            continue
         coins.append(
             {
                 "pair": pair,
@@ -72,6 +79,7 @@ def parse_mini_actions(text: str) -> Dict[str, List[Dict[str, Any]]]:
                 "sl": sl,
                 "tp1": tp1,
                 "tp2": tp2,
+                "tp3": tp3,
                 "risk": risk,
                 "conf": conf,
                 "rr": rr,
@@ -209,18 +217,21 @@ def enrich_tp_qty(exchange, acts: List[Dict[str, Any]], capital: float) -> List[
         sl = a.get("sl")
         tp1 = a.get("tp1")
         tp2 = a.get("tp2")
+        tp3 = a.get("tp3")
         risk = a.get("risk")
         if not (isinstance(entry, (int, float)) and isinstance(sl, (int, float))):
             continue
         dist = entry - sl
         tp1_def = entry + dist
-        tp2_def = entry + 1.5 * dist
+        tp2_def = entry + dist
         if not (isinstance(tp1, (int, float)) and tp1 != entry):
             tp1 = tp1_def
         if not (isinstance(tp2, (int, float)) and tp2 != entry):
             tp2 = tp2_def
         a["tp1"] = rfloat(tp1, 8)
         a["tp2"] = rfloat(tp2, 8)
+        if isinstance(tp3, (int, float)) and tp3 != entry:
+            a["tp3"] = rfloat(tp3, 8)
         rf = float(risk) if isinstance(risk, (int, float)) and risk > 0 else 0.01
         ccxt_sym = to_ccxt_symbol(a["pair"])
         step = qty_step(exchange, ccxt_sym)


### PR DESCRIPTION
## Summary
- parse mini-actions to include optional tp3 level and validate direction
- default tp1 and tp2 to the entry–SL distance when missing
- place partial closes: 20% at tp1, 30% at tp2, remainder market at tp3
- add unit test covering default tp computation and tp3 propagation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68afbca656ac8323903e4180760006a8