### PR TITLE
Skip trading during Asia hours

### DIFF
--- a/futures_gpt_orchestrator_full.py
+++ b/futures_gpt_orchestrator_full.py
@@ -180,6 +180,29 @@ def run(run_live: bool = False, limit: int = 30, ex=None) -> Dict[str, Any]:
     save_text(f"{stamp}_payload_full.json", dumps_min(payload_full))
     logger.info("Payload built with %d coins", len(payload_full.get("coins", [])))
 
+    time_info = payload_full.get("time", {})
+    if time_info.get("asia_block"):
+        logger.info("Asia session blocked, exiting run")
+        save_text(
+            f"{stamp}_orders.json",
+            dumps_min(
+                {
+                    "live": run_live,
+                    "capital": capital,
+                    "coins": [],
+                    "placed": [],
+                    "reason": "asia_block",
+                }
+            ),
+        )
+        return {
+            "ts": stamp,
+            "live": run_live,
+            "capital": capital,
+            "coins": [],
+            "placed": [],
+        }
+
     if not payload_full.get("coins"):
         logger.info("No coins in payload, exiting run")
         save_text(

--- a/payload_builder.py
+++ b/payload_builder.py
@@ -55,10 +55,15 @@ def _snap_with_cache(exchange, symbol: str, timeframe: str, cache, lock) -> Dict
 
 
 def time_payload(now: datetime | None = None) -> Dict:
-    """Return current UTC time info and trading session details."""
+    """Return current UTC time info and trading session details.
+
+    Includes ``asia_block`` flag to indicate 16h–01h UTC when no trades
+    should be opened.
+    """
 
     now = now or datetime.now(timezone.utc)
     utc_hour = now.hour
+    asia_block = utc_hour >= 16 or utc_hour < 1
     if 0 <= utc_hour < 8:
         session = "asia"
         end = now.replace(hour=8, minute=0, second=0, microsecond=0)
@@ -76,6 +81,7 @@ def time_payload(now: datetime | None = None) -> Dict:
         "utc_hour": utc_hour,
         "session": session,
         "mins_to_close": mins_to_close,
+        "asia_block": asia_block,
     }
 
 

--- a/prompts.py
+++ b/prompts.py
@@ -22,7 +22,7 @@ PROMPT_USER_MINI = (
     "- Funding filter: Chỉ xét nếu còn ≤60 phút tới kỳ funding; Long bất lợi khi rate>0, Short bất lợi khi rate<0. "
     "- Orderbook filter: imbalance ≥ 0.15 theo hướng lệnh và spread ≤ 0.1%. "
     "- ATR/SL filter: SL phải ≥ 0.6 × ATR(15m). "
-    "- Session filter: Asia yêu cầu conf ≥ 0.8, US yêu cầu conf ≥ 0.7. Nếu mins_to_close ≤ 15 và tín hiệu yếu → bỏ. "
+    "- Nếu mins_to_close ≤ 15 và tín hiệu yếu → bỏ. "
     "- Entry rule: Ưu tiên LIMIT pullback về EMA20/key level; nếu tín hiệu nến (pinbar/engulfing/doji/breakout) → đặt LIMIT tại 50% thân nến, không đuổi breakout nến 2–3. "
 
     "Trả về JSON duy nhất dạng {\"coins\":[{\"pair\":\"SYMBOL\",\"entry\":0.0,\"sl\":0.0,\"tp1\":0.0,\"conf\":0.0}]}. "

--- a/tests/test_payload_builder.py
+++ b/tests/test_payload_builder.py
@@ -231,13 +231,13 @@ def test_coin_payload_includes_higher_timeframes(monkeypatch):
     assert res["orderbook"]["sp"] == 0.1
 
 
-def test_time_payload_sessions():
+def test_time_payload_asia_block():
     from datetime import datetime, timezone
 
     now = datetime(2024, 1, 1, 2, 0, tzinfo=timezone.utc)
-    asia = payload_builder.time_payload(now)
-    assert asia["session"] == "asia" and asia["utc_hour"] == 2
+    info = payload_builder.time_payload(now)
+    assert info["session"] == "asia" and not info["asia_block"]
 
     now = datetime(2024, 1, 1, 18, 0, tzinfo=timezone.utc)
-    us = payload_builder.time_payload(now)
-    assert us["session"] == "us" and us["mins_to_close"] == 360
+    info = payload_builder.time_payload(now)
+    assert info["session"] == "us" and info["asia_block"]


### PR DESCRIPTION
## Summary
- add `asia_block` flag to time payload and skip run during 16h–01h UTC
- drop session filter from trading prompt
- test for new Asia blocking behaviour

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68affbe0234c83238c23b6cfb52007b8