### PR TITLE
Require GPT-provided TP levels

### DIFF
--- a/prompts.py
+++ b/prompts.py
@@ -25,7 +25,7 @@ PROMPT_USER_MINI = (
     "- Nếu mins_to_close ≤ 15 và tín hiệu yếu → bỏ. "
     "- Entry rule: Ưu tiên LIMIT pullback về EMA20/key level; nếu tín hiệu nến (pinbar/engulfing/doji/breakout) → đặt LIMIT tại 30-> 50% thân nến, không đuổi breakout nến 2–3. "
 
-    "Trả về JSON duy nhất dạng {\"coins\":[{\"pair\":\"SYMBOL\",\"entry\":0.0,\"sl\":0.0,\"tp1\":0.0,\"conf\":0.0}]}. "
+    "Trả về JSON duy nhất dạng {\"coins\":[{\"pair\":\"SYMBOL\",\"entry\":0.0,\"sl\":0.0,\"tp1\":0.0,\"tp2\":0.0,\"tp3\":0.0,\"conf\":0.0}]}. "
     "Không có tín hiệu hợp lệ → {\"coins\":[]}. "
 
     "DATA:{payload}"

--- a/tests/test_futures_gpt_orchestrator_full.py
+++ b/tests/test_futures_gpt_orchestrator_full.py
@@ -145,7 +145,7 @@ def test_run_cancels_existing_orders(monkeypatch, tmp_path):
     assert not (tmp_path / "BTCUSDT.json").exists()
 
 
-def test_run_places_order_without_tp3(monkeypatch, tmp_path):
+def test_run_skips_when_tp_missing(monkeypatch, tmp_path):
     class Ex:
         def __init__(self):
             self.orders = []
@@ -174,7 +174,11 @@ def test_run_places_order_without_tp3(monkeypatch, tmp_path):
     monkeypatch.setattr(orch, "build_payload", lambda ex, limit: {"coins": ["dummy"]})
     monkeypatch.setattr(orch, "send_openai", lambda *a, **k: {})
     monkeypatch.setattr(orch, "extract_content", lambda r: "")
-    monkeypatch.setattr(orch, "parse_mini_actions", lambda text: {"coins": [{"pair": "BTCUSDT", "entry": 1, "sl": 0.9, "tp1": 1.1}]})
+    monkeypatch.setattr(
+        orch,
+        "parse_mini_actions",
+        lambda text: {"coins": [{"pair": "BTCUSDT", "entry": 1, "sl": 0.9, "tp1": 1.1}]},
+    )
     monkeypatch.setattr(orch, "get_open_position_pairs", lambda e: set())
     monkeypatch.setattr(orch, "cancel_unpositioned_limits", lambda e: None)
     monkeypatch.setattr(orch, "remove_unmapped_limit_files", lambda e: None)
@@ -185,7 +189,7 @@ def test_run_places_order_without_tp3(monkeypatch, tmp_path):
 
     orch.run(run_live=True, ex=ex)
 
-    assert len(ex.orders) == 1
+    assert len(ex.orders) == 0
 
 
 @pytest.mark.parametrize("side,exit_side", [("buy", "sell"), ("sell", "buy")])

--- a/tests/test_trading_utils.py
+++ b/tests/test_trading_utils.py
@@ -37,7 +37,7 @@ def test_parse_mini_actions_handles_close():
     assert res["close_partial"] == [{"pair": "LTCUSDT", "pct": 25.0}]
 
 
-def test_enrich_tp_qty_defaults(monkeypatch):
+def test_enrich_tp_qty_keeps_tps(monkeypatch):
     ex = types.SimpleNamespace(
         market=lambda symbol: {"limits": {"leverage": {"max": 100}}, "contractSize": 1}
     )
@@ -48,14 +48,16 @@ def test_enrich_tp_qty_defaults(monkeypatch):
         lambda capital, rf, entry, sl, step, max_lev, contract: 1,
     )
     monkeypatch.setattr(trading_utils, "infer_side", lambda entry, sl, tp1: "buy")
-    acts = [{"pair": "BTCUSDT", "entry": 100, "sl": 90, "tp3": 150}]
+    acts = [
+        {"pair": "BTCUSDT", "entry": 100, "sl": 90, "tp1": 110, "tp2": 115, "tp3": 150}
+    ]
     res = trading_utils.enrich_tp_qty(ex, acts, capital=1000)
     assert res[0]["tp1"] == 110
     assert res[0]["tp2"] == 115
     assert res[0]["tp3"] == 150
 
 
-def test_enrich_tp_qty_sets_tp3_when_missing(monkeypatch):
+def test_enrich_tp_qty_skips_when_tp_missing(monkeypatch):
     ex = types.SimpleNamespace(
         market=lambda symbol: {"limits": {"leverage": {"max": 100}}, "contractSize": 1}
     )
@@ -66,6 +68,6 @@ def test_enrich_tp_qty_sets_tp3_when_missing(monkeypatch):
         lambda capital, rf, entry, sl, step, max_lev, contract: 1,
     )
     monkeypatch.setattr(trading_utils, "infer_side", lambda entry, sl, tp1: "buy")
-    acts = [{"pair": "BTCUSDT", "entry": 100, "sl": 90}]
+    acts = [{"pair": "BTCUSDT", "entry": 100, "sl": 90, "tp1": 110}]
     res = trading_utils.enrich_tp_qty(ex, acts, capital=1000)
-    assert res[0]["tp3"] == 115
+    assert res == []

--- a/trading_utils.py
+++ b/trading_utils.py
@@ -209,7 +209,10 @@ def infer_side(entry: float, sl: float, tp: Optional[float]) -> Optional[str]:
 
 
 def enrich_tp_qty(exchange, acts: List[Dict[str, Any]], capital: float) -> List[Dict[str, Any]]:
-    """Compute qty and default TP1/TP2/TP3 levels for each action."""
+    """Compute qty for each action, requiring TP1/TP2/TP3 from the model.
+
+    Actions missing any TP level are skipped.
+    """
 
     out: List[Dict[str, Any]] = []
     for a in acts:
@@ -219,19 +222,14 @@ def enrich_tp_qty(exchange, acts: List[Dict[str, Any]], capital: float) -> List[
         tp2 = a.get("tp2")
         tp3 = a.get("tp3")
         risk = a.get("risk")
-        if not (isinstance(entry, (int, float)) and isinstance(sl, (int, float))):
+        if not (
+            isinstance(entry, (int, float))
+            and isinstance(sl, (int, float))
+            and isinstance(tp1, (int, float))
+            and isinstance(tp2, (int, float))
+            and isinstance(tp3, (int, float))
+        ):
             continue
-        dist = entry - sl
-        tp1_def = entry + 1.0 * dist   # TP1 = 1R
-        tp2_def = entry + 1.5 * dist   # TP2 = 1.5R
-
-        if not (isinstance(tp1, (int, float)) and tp1 != entry):
-            tp1 = tp1_def
-        if not (isinstance(tp2, (int, float)) and tp2 != entry):
-            tp2 = tp2_def
-        tp3_def = tp2_def
-        if not (isinstance(tp3, (int, float)) and tp3 != entry):
-            tp3 = tp3_def
         a["tp1"] = rfloat(tp1, 8)
         a["tp2"] = rfloat(tp2, 8)
         a["tp3"] = rfloat(tp3, 8)


### PR DESCRIPTION
## Summary
- Ask GPT to return tp1, tp2 and tp3 in prompts
- Remove local TP calculation and require provided tp1/tp2/tp3 when enriching trades
- Adjust tests to expect supplied TP values and skip trades missing them

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b0488e91d88323a65a166da6f1d9a2