### PR TITLE
Filter low volume markets

### DIFF
--- a/exchange_utils.py
+++ b/exchange_utils.py
@@ -93,6 +93,7 @@ def cache_top_by_qv(
     *,
     ttl: float = 3600,
     path: str = "cache/top_volume.json",
+    min_qv: float = 0.0,
 ) -> List[str]:
     """Return top symbols by quote volume using a JSON cache.
 
@@ -124,12 +125,14 @@ def cache_top_by_qv(
 
     scored: Dict[str, Dict] = {}
     for sym, m in markets.items():
-        qv = (tickers.get(sym) or {}).get("quoteVolume") or 0
+        qv = float((tickers.get(sym) or {}).get("quoteVolume") or 0)
+        if qv < min_qv:
+            continue
         base = m.get("base") or ""
         norm = strip_numeric_prefix(base)
         info = scored.get(norm)
-        if not info or float(qv) > info["qv"]:
-            scored[norm] = {"symbol": sym, "qv": float(qv), "base": norm}
+        if not info or qv > info["qv"]:
+            scored[norm] = {"symbol": sym, "qv": qv, "base": norm}
 
     top = sorted(scored.values(), key=lambda x: x["qv"], reverse=True)[:limit]
 

--- a/payload_builder.py
+++ b/payload_builder.py
@@ -194,13 +194,18 @@ def build_payload(
     limit: int = 10,
     exclude_pairs: Set[str] | None = None,
     mc_ttl: float = 3600,
+    min_qv: float = 10_000_000,
 ) -> Dict:
-    """Build the payload used by the orchestrator with time and bias info."""
+    """Build the payload used by the orchestrator with time and bias info.
+
+    Only markets with quote volume above ``min_qv`` are considered when
+    selecting trading symbols.
+    """
 
     exclude_pairs = exclude_pairs or set()
     positions = positions_snapshot(exchange)
     pos_pairs = {p.get("pair") for p in positions}
-    volumes = cache_top_by_qv(exchange, limit=limit)
+    volumes = cache_top_by_qv(exchange, limit=limit, min_qv=min_qv)
     mc_list = top_by_market_cap(max(limit, 200), ttl=mc_ttl)
     mc_bases = set(mc_list)
     markets = load_usdtm(exchange)

--- a/tests/test_build_payload.py
+++ b/tests/test_build_payload.py
@@ -13,7 +13,7 @@ class DummyExchange:
 def test_build_payload_fills_from_market_cap(monkeypatch):
     monkeypatch.setattr(pb, "positions_snapshot", lambda ex: [])
     monkeypatch.setattr(pb, "coin_payload", lambda ex, sym: {"p": pb.norm_pair_symbol(sym)})
-    monkeypatch.setattr(pb, "cache_top_by_qv", lambda ex, limit=10: [])
+    monkeypatch.setattr(pb, "cache_top_by_qv", lambda ex, limit=10, min_qv=0: [])
     monkeypatch.setattr(pb, "top_by_market_cap", lambda lim, ttl=3600: ["AAA", "BBB"])
     monkeypatch.setattr(
         pb,
@@ -25,7 +25,7 @@ def test_build_payload_fills_from_market_cap(monkeypatch):
     )
     monkeypatch.setattr(pb, "_snap_with_cache", lambda *a, **k: {"ema": 0})
 
-    payload = pb.build_payload(DummyExchange(), limit=2)
+    payload = pb.build_payload(DummyExchange(), limit=2, min_qv=0)
     pairs = {c["p"] for c in payload["coins"]}
     assert pairs == {"AAAUSDT", "BBBUSDT"}
     assert "time" in payload and "eth" in payload
@@ -34,7 +34,7 @@ def test_build_payload_fills_from_market_cap(monkeypatch):
 def test_build_payload_handles_numeric_prefix(monkeypatch):
     monkeypatch.setattr(pb, "positions_snapshot", lambda ex: [])
     monkeypatch.setattr(pb, "coin_payload", lambda ex, sym: {"p": pb.norm_pair_symbol(sym)})
-    monkeypatch.setattr(pb, "cache_top_by_qv", lambda ex, limit=10: [])
+    monkeypatch.setattr(pb, "cache_top_by_qv", lambda ex, limit=10, min_qv=0: [])
     monkeypatch.setattr(pb, "top_by_market_cap", lambda lim, ttl=3600: ["PEPE"])
     monkeypatch.setattr(
         pb,
@@ -43,7 +43,7 @@ def test_build_payload_handles_numeric_prefix(monkeypatch):
     )
     monkeypatch.setattr(pb, "_snap_with_cache", lambda *a, **k: {"ema": 0})
 
-    payload = pb.build_payload(DummyExchange(), limit=1)
+    payload = pb.build_payload(DummyExchange(), limit=1, min_qv=0)
     pairs = {c["p"] for c in payload["coins"]}
     assert pairs == {"1000PEPEUSDT"}
     assert "time" in payload and "eth" in payload
@@ -57,7 +57,7 @@ def test_build_payload_prioritizes_gainers_and_skips_positions(monkeypatch):
     monkeypatch.setattr(
         pb,
         "cache_top_by_qv",
-        lambda ex, limit=10: ["CCC/USDT:USDT", "BBB/USDT:USDT"],
+        lambda ex, limit=10, min_qv=0: ["CCC/USDT:USDT", "BBB/USDT:USDT"],
     )
     monkeypatch.setattr(pb, "top_by_market_cap", lambda lim, ttl=3600: ["AAA", "BBB", "CCC"])
     monkeypatch.setattr(
@@ -71,6 +71,6 @@ def test_build_payload_prioritizes_gainers_and_skips_positions(monkeypatch):
     )
     monkeypatch.setattr(pb, "_snap_with_cache", lambda *a, **k: {"ema": 0})
 
-    payload = pb.build_payload(DummyExchange(), limit=2)
+    payload = pb.build_payload(DummyExchange(), limit=2, min_qv=0)
     pairs = [c["p"] for c in payload["coins"]]
     assert pairs == ["CCCUSDT", "AAAUSDT"]

--- a/tests/test_exchange_utils.py
+++ b/tests/test_exchange_utils.py
@@ -135,3 +135,39 @@ def test_cache_top_by_qv_caches_results(monkeypatch, tmp_path):
     with open(path, "r", encoding="utf-8") as fh:
         data = json.load(fh)
     assert data[0]["base"] == "AAA"
+
+
+def test_cache_top_by_qv_filters_by_min_qv(tmp_path):
+    class DummyExchange:
+        def load_markets(self):
+            return {
+                "AAA/USDT:USDT": {
+                    "symbol": "AAA/USDT:USDT",
+                    "linear": True,
+                    "swap": True,
+                    "quote": "USDT",
+                    "active": True,
+                    "base": "AAA",
+                },
+                "BBB/USDT:USDT": {
+                    "symbol": "BBB/USDT:USDT",
+                    "linear": True,
+                    "swap": True,
+                    "quote": "USDT",
+                    "active": True,
+                    "base": "BBB",
+                },
+            }
+
+        def fetch_tickers(self):
+            return {
+                "AAA/USDT:USDT": {"quoteVolume": 6_000_000},
+                "BBB/USDT:USDT": {"quoteVolume": 1_000_000},
+            }
+
+    ex = DummyExchange()
+    path = tmp_path / "vol.json"
+    res = exchange_utils.cache_top_by_qv(
+        ex, limit=2, ttl=0, path=str(path), min_qv=5_000_000
+    )
+    assert res == ["AAA/USDT:USDT"]


### PR DESCRIPTION
## Summary
- Filter top-volume cache to drop markets below a minimum 24h quote volume
- Expose `min_qv` threshold in `build_payload` to skip low-liquidity coins
- Add unit test covering minimum volume filtering

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b13924d6348323857e85544fe99a26