### PR TITLE
Clarify limit order expiry units and convert to seconds

### DIFF
--- a/futures_gpt_orchestrator_full.py
+++ b/futures_gpt_orchestrator_full.py
@@ -245,7 +245,13 @@ def run(run_live: bool = False, limit: int = 30, ex=None) -> Dict[str, Any]:
                 entry_order = ex.create_order(
                     ccxt_sym, "limit", side, qty, entry, {"reduceOnly": False}
                 )
-                expiry = c.get("expiry")
+                expiry_min = c.get("expiry")
+                try:
+                    expiry_sec = (
+                        float(expiry_min) * 60 if expiry_min not in (None, "") else None
+                    )
+                except Exception:
+                    expiry_sec = None
                 save_text(
                     f"{pair}.json",
                     dumps_min(
@@ -257,7 +263,7 @@ def run(run_live: bool = False, limit: int = 30, ex=None) -> Dict[str, Any]:
                             "qty": qty,
                             "sl": sl,
                             "tp1": tp1,
-                            "expiry": expiry,
+                            "expiry": expiry_sec,
                             "ts": time.time(),
                         }
                     ),
@@ -272,7 +278,7 @@ def run(run_live: bool = False, limit: int = 30, ex=None) -> Dict[str, Any]:
                         "tp1": tp1,
                         "qty": qty,
                         "entry_id": entry_order.get("id"),
-                        "expiry": expiry,
+                        "expiry": expiry_min,
                     }
                 )
             except Exception as e:

--- a/prompts.py
+++ b/prompts.py
@@ -26,6 +26,7 @@ PROMPT_USER_MINI = (
     "- Entry rule: Ưu tiên LIMIT pullback về EMA20/key level; nếu tín hiệu nến (pinbar/engulfing/doji/breakout) → đặt LIMIT tại 30-> 50% thân nến, không đuổi breakout nến 2–3. "
 
     "Trả về JSON duy nhất dạng {\"coins\":[{\"pair\":\"SYMBOL\",\"entry\":0.0,\"sl\":0.0,\"tp\":0.0,\"risk\":0.0,\"expiry\":0}]}. "
+    "Trong đó \"expiry\" là số phút trước khi lệnh LIMIT hết hạn; bot tự hủy nếu chưa khớp. "
     "Không có tín hiệu hợp lệ → {\"coins\":[]}. "
 
     "DATA:{payload}"


### PR DESCRIPTION
## Summary
- Clarify in prompts that `expiry` is the number of minutes before a LIMIT order expires and self-cancels
- Convert `expiry` from minutes to seconds when saving limit order metadata

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b13c6637c883239dcc81e21cdef0e6