### PR TITLE
Check open positions limit instead of open orders

### DIFF
--- a/futures_gpt_orchestrator_full.py
+++ b/futures_gpt_orchestrator_full.py
@@ -164,15 +164,15 @@ def run(run_live: bool = False, limit: int = 30, ex=None) -> Dict[str, Any]:
     stamp = ts_prefix()
 
     if run_live:
-        max_orders = env_int("MAX_OPEN_ORDERS", 10)
+        max_pos = env_int("MAX_OPEN_POSITIONS", 10)
         try:
-            current_orders = len(ex.fetch_open_orders())
+            current_pos = len(get_open_position_pairs(ex))
         except Exception as e:
-            logger.warning("run fetch_open_orders error: %s", e)
-            current_orders = 0
-        if current_orders >= max_orders:
+            logger.warning("run get_open_position_pairs error: %s", e)
+            current_pos = 0
+        if current_pos >= max_pos:
             logger.info(
-                "Open orders %s >= max %s, exiting run", current_orders, max_orders
+                "Open positions %s >= max %s, exiting run", current_pos, max_pos
             )
             save_text(
                 f"{stamp}_orders.json",
@@ -182,7 +182,7 @@ def run(run_live: bool = False, limit: int = 30, ex=None) -> Dict[str, Any]:
                         "capital": capital,
                         "coins": [],
                         "placed": [],
-                        "reason": "max_orders",
+                        "reason": "max_positions",
                     }
                 ),
             )

--- a/tests/test_futures_gpt_orchestrator_full.py
+++ b/tests/test_futures_gpt_orchestrator_full.py
@@ -191,13 +191,10 @@ def test_run_skips_when_tp_missing(monkeypatch, tmp_path):
     assert len(ex.orders) == 0
 
 
-def test_run_respects_max_open_orders(monkeypatch):
+def test_run_respects_max_open_positions(monkeypatch):
     class Ex:
         def fetch_balance(self):
             return {"total": {"USDT": 1000}}
-
-        def fetch_open_orders(self):
-            return list(range(11))
 
     ex = Ex()
     monkeypatch.setattr(orch, "load_env", lambda: None)
@@ -207,6 +204,7 @@ def test_run_respects_max_open_orders(monkeypatch):
     monkeypatch.setattr(orch, "cancel_unpositioned_limits", lambda e: None)
     monkeypatch.setattr(orch, "remove_unmapped_limit_files", lambda e: None)
     monkeypatch.setattr(orch, "env_int", lambda k, d: 10)
+    monkeypatch.setattr(orch, "get_open_position_pairs", lambda e: {f"p{i}" for i in range(11)})
     build_called = {}
 
     def fake_build_payload(*a, **k):


### PR DESCRIPTION
## Summary
- Limit trading runs based on existing positions rather than open orders using `get_open_position_pairs`
- Update unit tests to verify run halts when max open positions exceeded

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b18c7c5e508323946813cc7aba4cc2