### PR TITLE
feat: configure limit expiry

### DIFF
--- a/futures_gpt_orchestrator_full.py
+++ b/futures_gpt_orchestrator_full.py
@@ -63,6 +63,8 @@ logger = logging.getLogger(__name__)
 
 # Directory inside ``outputs`` where limit order metadata is stored
 LIMIT_ORDER_DIR = Path("outputs") / "limit_orders"
+# Default expiry for limit orders in minutes
+LIMIT_ORDER_EXPIRY_MIN = env_int("LIMIT_ORDER_EXPIRY_MIN", 30)
 
 
 def cancel_all_orders_for_pair(exchange, symbol: str, pair: str) -> None:
@@ -255,13 +257,8 @@ def run(run_live: bool = False, limit: int = 30, ex=None) -> Dict[str, Any]:
                 entry_order = ex.create_order(
                     ccxt_sym, "limit", side, qty, entry, {"reduceOnly": False}
                 )
-                expiry_min = c.get("expiry")
-                try:
-                    expiry_sec = (
-                        float(expiry_min) * 60 if expiry_min not in (None, "") else None
-                    )
-                except Exception:
-                    expiry_sec = None
+                expiry_min = LIMIT_ORDER_EXPIRY_MIN
+                expiry_sec = float(expiry_min) * 60 if expiry_min else None
                 save_text(
                     f"{pair}.json",
                     dumps_min(

--- a/prompts.py
+++ b/prompts.py
@@ -6,14 +6,14 @@ from env_utils import dumps_min
 PROMPT_SYS_MINI = (
     "You are a professional crypto trader. "
     "Analyze market data and output ONLY valid JSON. "
-    "Output {\"coins\":[{\"pair\":\"SYMBOL\",\"entry\":0.0,\"sl\":0.0,\"tp\":0.0,\"conf\":0.0,\"expiry\":0}]}. "
+    "Output {\"coins\":[{\"pair\":\"SYMBOL\",\"entry\":0.0,\"sl\":0.0,\"tp\":0.0,\"conf\":0.0}]}. "
     "No prose. No markdown. If no trade, return {\"coins\":[]}."
 )
 
 PROMPT_USER_MINI = (
     # "NHIỆM VỤ: Chọn ≤6 coin từ PAYLOAD 15m + H1/H4. "
     # "Trả JSON: {\"coins\":[{\"pair\":\"SYMBOL\",\"entry\":0.0,\"sl\":0.0,"
-    # "\"tp\":0.0,\"conf\":0.0,\"expiry\":0}]}. Nếu không có: {\"coins\":[]}. "
+    # "\"tp\":0.0,\"conf\":0.0}]}. Nếu không có: {\"coins\":[]}. "
     # "RULE: "
     # "- Long: last_close>ema20(15m) & H1.t∈{0,1} & H4.t∈{0,1} & rsi14>50 & macd_hist>0. "
     # "- Short: last_close<ema20(15m) & H1.t∈{-1,0} & H4.t∈{-1,0} & rsi14<50 & macd_hist<0. "
@@ -32,7 +32,7 @@ PROMPT_USER_MINI = (
 # PROMPT_USER_MINI = (
 #     # "Nhiệm vụ: phân tích 15m (20 nến + chỉ báo) tham chiếu H1/H4 từ payload; chọn TỐI ĐA 6 coin phù hợp. "
 #     # "Trả về JSON DUY NHẤT theo schema: "
-#     # "{\"coins\":[{\"pair\":\"SYMBOL\",\"entry\":0.0,\"sl\":0.0,\"tp\":0.0,\"conf\":0.0,\"expiry\":0}]}. "
+#     # "{\"coins\":[{\"pair\":\"SYMBOL\",\"entry\":0.0,\"sl\":0.0,\"tp\":0.0,\"conf\":0.0}]}. "
 #     # "Chỉ chọn khi conf ≥ 7.0 và RR(=|tp-entry|/|entry-sl|) ≥ 1.8. "
 #     # "Quy tắc: "
 #     # "- Trend: Long khi close15m>EMA20 & H1/H4 trend=up; Short khi close15m<EMA20 & H1/H4 trend=down. "
@@ -74,7 +74,7 @@ PROMPT_USER_MINI = (
 #     # "- Nếu mins_to_close ≤ 15 và tín hiệu yếu → bỏ. "
 #     # "- Entry rule: Ưu tiên LIMIT pullback về EMA20/key level; nếu tín hiệu nến (pinbar/engulfing/doji/breakout) → đặt LIMIT tại 30-> 50% thân nến, không đuổi breakout nến 2–3. "
 
-#     "Trả về JSON duy nhất dạng {\"coins\":[{\"pair\":\"SYMBOL\",\"entry\":0.0,\"sl\":0.0,\"tp\":0.0,\"conf\":0.0,\"expiry\":0}]}. "
+#     "Trả về JSON duy nhất dạng {\"coins\":[{\"pair\":\"SYMBOL\",\"entry\":0.0,\"sl\":0.0,\"tp\":0.0,\"conf\":0.0}]}. "
 #     "Trong đó \"expiry\" là số phút trước khi lệnh LIMIT hết hạn; bot tự hủy nếu chưa khớp. "
 #     "Không có tín hiệu hợp lệ → {\"coins\":[]}. "
 

--- a/tests/test_trading_utils.py
+++ b/tests/test_trading_utils.py
@@ -23,7 +23,7 @@ def test_parse_mini_actions_handles_close():
     text = (
         "{"
         '"coins":[{"pair":"BTCUSDT","entry":1,"sl":0.9,"tp":1.05,'
-        '"risk":0.1,"expiry":120}],'
+        '"risk":0.1}],'
         '"close_all":[{"pair":"ETHUSDT"}],'
         '"close_partial":[{"pair":"LTCUSDT","pct":25}]}'
     )
@@ -31,7 +31,7 @@ def test_parse_mini_actions_handles_close():
     assert res["coins"] and res["coins"][0]["pair"] == "BTCUSDT"
     assert res["coins"][0]["tp1"] == 1.05
     assert res["coins"][0]["risk"] == 0.1
-    assert res["coins"][0]["expiry"] == 120.0
+    assert "expiry" not in res["coins"][0]
     assert res["close_all"] == [{"pair": "ETHUSDT"}]
     assert res["close_partial"] == [{"pair": "LTCUSDT", "pct": 25.0}]
 

--- a/trading_utils.py
+++ b/trading_utils.py
@@ -14,8 +14,8 @@ def parse_mini_actions(text: str) -> Dict[str, List[Dict[str, Any]]]:
     """Parse MINI model JSON output into open/close instructions.
 
     Returns a dict with keys ``coins``, ``close_all`` and ``close_partial``.
-    ``coins`` contains dicts with trading instructions (entry, SL, TP1, risk,
-    expiry). ``close_all`` is a list of {"pair"} dicts. ``close_partial`` is a list of
+    ``coins`` contains dicts with trading instructions (entry, SL, TP1, risk).
+    ``close_all`` is a list of {"pair"} dicts. ``close_partial`` is a list of
     {"pair", "pct"} dicts where ``pct`` is a percentage between 0 and 100.
     Invalid entries are ignored silently.
     """
@@ -38,7 +38,6 @@ def parse_mini_actions(text: str) -> Dict[str, List[Dict[str, Any]]]:
         risk = item.get("risk")
         conf = item.get("conf")
         rr = item.get("rr")
-        expiry = item.get("expiry")
         try:
             entry = float(entry) if entry is not None else None
             sl = float(sl) if sl is not None else None
@@ -46,7 +45,6 @@ def parse_mini_actions(text: str) -> Dict[str, List[Dict[str, Any]]]:
             risk = float(risk) if risk not in (None, "") else None
             conf = float(conf) if conf not in (None, "") else None
             rr = float(rr) if rr not in (None, "") else None
-            expiry = float(expiry) if expiry not in (None, "") else None
         except Exception:
             continue
         if None in (entry, sl) or entry == sl:
@@ -68,7 +66,6 @@ def parse_mini_actions(text: str) -> Dict[str, List[Dict[str, Any]]]:
                 "risk": risk,
                 "conf": conf,
                 "rr": rr,
-                "expiry": expiry,
             }
         )
 


### PR DESCRIPTION
## Summary
- configure default limit order expiry via `LIMIT_ORDER_EXPIRY_MIN`
- drop expiry parsing from GPT prompts and actions
- update tests accordingly

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b2b62fdc74832392f89f68dde0513a