### PR TITLE
Support 1h/4h/1d data with 200-candle payloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # scalping_15m
 
-Automated trading bot orchestrator with scheduled checks and order management.
+Automated trading bot orchestrator for 1h timeframe with 4h/1d context, including scheduled checks and order management.
 
 This build automatically removes JSON metadata for cancelled or unmapped limit orders without open positions before calling the GPT API.
 

--- a/backtest.py
+++ b/backtest.py
@@ -65,7 +65,7 @@ def run_backtest(symbol: str, timeframe: str, limit: int, since: int | None) -> 
 def _parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Run a simple backtest")
     parser.add_argument("--symbol", default="BTC/USDT", help="CCXT symbol, e.g. BTC/USDT")
-    parser.add_argument("--timeframe", default="15m", help="Candle timeframe")
+    parser.add_argument("--timeframe", default="1h", help="Candle timeframe")
     parser.add_argument("--limit", type=int, default=500, help="Number of candles to fetch")
     parser.add_argument(
         "--since", type=int, default=None, help="Optional start timestamp in milliseconds"

--- a/deploy.sh
+++ b/deploy.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 step=1
 step() { echo -e "\n[$step] $1"; step=$((step+1)); }
 
-echo "🚀 Starting full deployment for scalping 15m bot..."
+echo "🚀 Starting full deployment for 1h trading bot..."
 
 step "Ensure python3 and pip are available"
 if ! command -v python3 >/dev/null; then

--- a/futures_gpt_orchestrator_full.py
+++ b/futures_gpt_orchestrator_full.py
@@ -1,4 +1,4 @@
-"""Futures → GPT Orchestrator (15m focus, H4/D1 context; retains ETH bias).
+"""Futures → GPT Orchestrator (1h focus, 4h/D1 context; retains ETH bias).
 
 This script orchestrates the flow:
 1. Build payloads from market data

--- a/prompts.py
+++ b/prompts.py
@@ -4,7 +4,7 @@ from env_utils import dumps_min
 
 
 PROMPT_SYS_MINI = (
-    "Bạn là 1 chuyên gia trading scalping khung 15m (base theo 1h/4h). Dùng tất cả data trong payload để phân tích vào lệnh"
+    "Bạn là 1 chuyên gia trading khung 1h (tham chiếu 4h/1d). Dùng 200 nến mỗi khung trong payload để phân tích vào lệnh"
     "Ưu tiên chọn entry hợp lý, conf >= 6.5 và RR >= 1.8."
     "Output {\"coins\":[{\"pair\":\"SYMBOL\",\"entry\":0.0,\"sl\":0.0,\"tp\":0.0,\"conf\":0.0,\"expiry\":0}]}. "
     "No prose. No markdown. If no trade, return {\"coins\":[]}."

--- a/tests/test_build_payload.py
+++ b/tests/test_build_payload.py
@@ -19,7 +19,7 @@ def test_build_payload_uses_top_volume(monkeypatch):
         lambda ex, limit=10, min_qv=0: ["AAA/USDT:USDT", "BBB/USDT:USDT"],
     )
     monkeypatch.setattr(pb, "top_by_market_cap", lambda limit=200: ["AAA", "BBB"])
-    monkeypatch.setattr(pb, "_snap_with_cache", lambda *a, **k: {"ema": 0})
+    monkeypatch.setattr(pb, "_tf_with_cache", lambda *a, **k: {"ema": 0})
 
     payload = pb.build_payload(DummyExchange(), limit=2, min_qv=0)
     pairs = {c["p"] for c in payload["coins"]}
@@ -36,7 +36,7 @@ def test_build_payload_handles_numeric_prefix(monkeypatch):
         lambda ex, limit=10, min_qv=0: ["1000PEPE/USDT:USDT"],
     )
     monkeypatch.setattr(pb, "top_by_market_cap", lambda limit=200: ["PEPE"])
-    monkeypatch.setattr(pb, "_snap_with_cache", lambda *a, **k: {"ema": 0})
+    monkeypatch.setattr(pb, "_tf_with_cache", lambda *a, **k: {"ema": 0})
 
     payload = pb.build_payload(DummyExchange(), limit=1, min_qv=0)
     pairs = {c["p"] for c in payload["coins"]}
@@ -57,7 +57,7 @@ def test_build_payload_skips_positions(monkeypatch):
         ],
     )
     monkeypatch.setattr(pb, "top_by_market_cap", lambda limit=200: ["CCC", "BBB", "AAA"])
-    monkeypatch.setattr(pb, "_snap_with_cache", lambda *a, **k: {"ema": 0})
+    monkeypatch.setattr(pb, "_tf_with_cache", lambda *a, **k: {"ema": 0})
 
     payload = pb.build_payload(DummyExchange(), limit=2, min_qv=0)
     pairs = [c["p"] for c in payload["coins"]]

--- a/tests/test_payload_builder.py
+++ b/tests/test_payload_builder.py
@@ -5,7 +5,7 @@ sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
 import payload_builder  # noqa: E402
 
 
-def test_build_15m_adds_volume(monkeypatch):
+def test_build_tf_adds_volume(monkeypatch):
     import pandas as pd
 
     def fake_add_indicators(df):
@@ -35,14 +35,14 @@ def test_build_15m_adds_volume(monkeypatch):
             "close": [1.05, 2.05],
             "volume": [100.0, 200.0],
         },
-        index=pd.date_range("2024-01-01", periods=2, freq="15min"),
+        index=pd.date_range("2024-01-01", periods=2, freq="1h"),
     )
 
-    res = payload_builder.build_15m(df)
+    res = payload_builder.build_tf(df)
     assert all(len(candle) == 5 for candle in res["ohlcv"])
 
 
-def test_build_15m_volume_numeric(monkeypatch):
+def test_build_tf_volume_numeric(monkeypatch):
     import pandas as pd
 
     def fake_add_indicators(df):
@@ -72,14 +72,14 @@ def test_build_15m_volume_numeric(monkeypatch):
             "close": [1.05, 2.05],
             "volume": [100.0, 312066130.0],
         },
-        index=pd.date_range("2024-01-01", periods=2, freq="15min"),
+        index=pd.date_range("2024-01-01", periods=2, freq="1h"),
     )
 
-    res = payload_builder.build_15m(df)
+    res = payload_builder.build_tf(df)
     assert res["ohlcv"][-1][-1] == "312M"
 
 
-def test_build_15m_limits_length_and_snap(monkeypatch):
+def test_build_tf_limits_length_and_snap(monkeypatch):
     import pandas as pd
 
     def fake_add_indicators(df):
@@ -104,18 +104,18 @@ def test_build_15m_limits_length_and_snap(monkeypatch):
 
     df = pd.DataFrame(
         {
-            "open": range(25),
-            "high": range(25),
-            "low": range(25),
-            "close": range(25),
-            "volume": range(25),
+            "open": range(205),
+            "high": range(205),
+            "low": range(205),
+            "close": range(205),
+            "volume": range(205),
         },
-        index=pd.date_range("2024-01-01", periods=25, freq="15min"),
+        index=pd.date_range("2024-01-01", periods=205, freq="1h"),
     )
 
-    res = payload_builder.build_15m(df)
-    assert len(res["ohlcv"]) == 20
-    assert all(len(v) == 20 for v in res["ind"].values())
+    res = payload_builder.build_tf(df)
+    assert len(res["ohlcv"]) == 200
+    assert all(len(v) == 200 for v in res["ind"].values())
     assert set(res["ind"].keys()) == {
         "ema20",
         "ema50",
@@ -129,7 +129,7 @@ def test_build_15m_limits_length_and_snap(monkeypatch):
         "vol_spike",
     }
 
-    snap = payload_builder.build_15m(df, limit=1)
+    snap = payload_builder.build_tf(df, limit=1)
     expected = payload_builder.build_snap(df)
     assert snap == expected
 
@@ -164,7 +164,7 @@ def test_build_snap_rounds_price(monkeypatch):
             "close": [1.05],
             "volume": [100.0],
         },
-        index=pd.date_range("2024-01-01", periods=1, freq="15min"),
+        index=pd.date_range("2024-01-01", periods=1, freq="1h"),
     )
 
     snap = payload_builder.build_snap(df)
@@ -174,9 +174,9 @@ def test_build_snap_rounds_price(monkeypatch):
 def test_coin_payload_includes_higher_timeframes(monkeypatch):
     import pandas as pd
 
-    payload_builder.CACHE_M15.clear()
     payload_builder.CACHE_H1.clear()
     payload_builder.CACHE_H4.clear()
+    payload_builder.CACHE_D1.clear()
 
     def fake_fetch(exchange, symbol, timeframe, limit, since=None):
         return pd.DataFrame(
@@ -187,7 +187,7 @@ def test_coin_payload_includes_higher_timeframes(monkeypatch):
                 "close": [1.0],
                 "volume": [1.0],
             },
-            index=pd.date_range("2024-01-01", periods=1, freq="15min", tz="UTC"),
+            index=pd.date_range("2024-01-01", periods=1, freq="1h", tz="UTC"),
         )
 
     def fake_add_indicators(df):
@@ -219,9 +219,9 @@ def test_coin_payload_includes_higher_timeframes(monkeypatch):
     res = payload_builder.coin_payload(None, "BTC/USDT:USDT")
     assert {
         "pair",
-        "m15",
         "h1",
         "h4",
+        "d1",
         "funding",
         "oi",
         "cvd",


### PR DESCRIPTION
## Summary
- Build payloads from 1h/4h/1d timeframes and expose 200 candles per frame
- Update prompts and docs to reflect the new higher timeframes
- Default backtest timeframe set to 1h and deployment message updated

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b3f5fc84b4832398250e9a5560a02f