### PR TITLE
Configure trading pairs via env and remove ETH bias

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,7 @@ Automated trading bot orchestrator for 1h timeframe with 4h/1d context, includin
 This build automatically removes JSON metadata for cancelled or unmapped limit orders without open positions before calling the GPT API.
 
 The stop-loss manager shifts the stop-loss to the entry price once the first take-profit is hit.
+
+## Configuration
+
+Specify the trading pairs to analyse via the `COIN_PAIRS` variable in your `.env` file. Use a comma-separated list of pairs (e.g. `COIN_PAIRS=BTCUSDT,ETHUSDT`).

--- a/tests/test_build_payload.py
+++ b/tests/test_build_payload.py
@@ -10,55 +10,36 @@ class DummyExchange:
     pass
 
 
-def test_build_payload_uses_top_volume(monkeypatch):
+def test_build_payload_from_env_pairs(monkeypatch):
+    monkeypatch.setenv("COIN_PAIRS", "AAA,BBB")
     monkeypatch.setattr(pb, "positions_snapshot", lambda ex: [])
     monkeypatch.setattr(pb, "coin_payload", lambda ex, sym: {"p": pb.norm_pair_symbol(sym)})
-    monkeypatch.setattr(
-        pb,
-        "cache_top_by_qv",
-        lambda ex, limit=10, min_qv=0: ["AAA/USDT:USDT", "BBB/USDT:USDT"],
-    )
-    monkeypatch.setattr(pb, "top_by_market_cap", lambda limit=200: ["AAA", "BBB"])
     monkeypatch.setattr(pb, "_tf_with_cache", lambda *a, **k: {"ema": 0})
 
-    payload = pb.build_payload(DummyExchange(), limit=2, min_qv=0)
+    payload = pb.build_payload(DummyExchange(), limit=2)
     pairs = {c["p"] for c in payload["coins"]}
     assert pairs == {"AAAUSDT", "BBBUSDT"}
-    assert "time" in payload and "eth" in payload
+    assert "time" in payload and "eth" not in payload
 
 
 def test_build_payload_handles_numeric_prefix(monkeypatch):
+    monkeypatch.setenv("COIN_PAIRS", "1000PEPE")
     monkeypatch.setattr(pb, "positions_snapshot", lambda ex: [])
     monkeypatch.setattr(pb, "coin_payload", lambda ex, sym: {"p": pb.norm_pair_symbol(sym)})
-    monkeypatch.setattr(
-        pb,
-        "cache_top_by_qv",
-        lambda ex, limit=10, min_qv=0: ["1000PEPE/USDT:USDT"],
-    )
-    monkeypatch.setattr(pb, "top_by_market_cap", lambda limit=200: ["PEPE"])
     monkeypatch.setattr(pb, "_tf_with_cache", lambda *a, **k: {"ema": 0})
 
-    payload = pb.build_payload(DummyExchange(), limit=1, min_qv=0)
+    payload = pb.build_payload(DummyExchange(), limit=1)
     pairs = {c["p"] for c in payload["coins"]}
     assert pairs == {"1000PEPEUSDT"}
-    assert "time" in payload and "eth" in payload
+    assert "time" in payload and "eth" not in payload
 
 
 def test_build_payload_skips_positions(monkeypatch):
+    monkeypatch.setenv("COIN_PAIRS", "CCCUSDT,BBBUSDT,AAAUSDT")
     monkeypatch.setattr(pb, "positions_snapshot", lambda ex: [{"pair": "BBBUSDT"}])
     monkeypatch.setattr(pb, "coin_payload", lambda ex, sym: {"p": pb.norm_pair_symbol(sym)})
-    monkeypatch.setattr(
-        pb,
-        "cache_top_by_qv",
-        lambda ex, limit=10, min_qv=0: [
-            "CCC/USDT:USDT",
-            "BBB/USDT:USDT",
-            "AAA/USDT:USDT",
-        ],
-    )
-    monkeypatch.setattr(pb, "top_by_market_cap", lambda limit=200: ["CCC", "BBB", "AAA"])
     monkeypatch.setattr(pb, "_tf_with_cache", lambda *a, **k: {"ema": 0})
 
-    payload = pb.build_payload(DummyExchange(), limit=2, min_qv=0)
+    payload = pb.build_payload(DummyExchange(), limit=2)
     pairs = [c["p"] for c in payload["coins"]]
     assert pairs == ["CCCUSDT", "AAAUSDT"]


### PR DESCRIPTION
## Summary
- read target pairs from `COIN_PAIRS` environment variable instead of 24h top coins
- drop common ETH context from orchestrator payload
- document new `COIN_PAIRS` setting and adjust tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b4550f9d788323bb1d3cfb7eaa6f1c