### PR TITLE
feat: support multi-target take profit

### DIFF
--- a/futures_gpt_orchestrator_full.py
+++ b/futures_gpt_orchestrator_full.py
@@ -102,8 +102,14 @@ def cancel_all_orders_for_pair(exchange, symbol: str, pair: str) -> None:
         logger.warning("cancel_all_orders_for_pair unlink error %s: %s", fp, e)
 
 
-def _place_sl_tp(exchange, symbol, side, qty, sl, tp1):
-    """Place stop-loss and a single take-profit order."""
+def _place_sl_tp(exchange, symbol, side, qty, sl, tp1, tp2=None, tp3=None):
+    """Place stop-loss and up to three take-profit orders.
+
+    If ``qty`` is ``None`` or only ``tp1`` is provided, a single take-profit
+    order closing the entire position is used. When ``tp2``/``tp3`` are given
+    and ``qty`` is provided, the position is split 30/50/20 percent across the
+    three targets using reduce-only orders.
+    """
 
     exit_side = "sell" if side == "buy" else "buy"
     params_close = {"closePosition": True}
@@ -131,14 +137,54 @@ def _place_sl_tp(exchange, symbol, side, qty, sl, tp1):
             None,
             {**params_close, "stopPrice": sl},
         )
-        exchange.create_order(
-            symbol,
-            "TAKE_PROFIT_MARKET",
-            exit_side,
-            None,
-            None,
-            {**params_close, "stopPrice": tp1},
-        )
+        if qty is None:
+            exchange.create_order(
+                symbol,
+                "TAKE_PROFIT_MARKET",
+                exit_side,
+                None,
+                None,
+                {**params_close, "stopPrice": tp1},
+            )
+        elif tp2 is None and tp3 is None:
+            exchange.create_order(
+                symbol,
+                "LIMIT",
+                exit_side,
+                qty,
+                tp1,
+                {"reduceOnly": True},
+            )
+        else:
+            q1 = qty * 0.3
+            q2 = qty * 0.5
+            q3 = qty - q1 - q2
+            exchange.create_order(
+                symbol,
+                "LIMIT",
+                exit_side,
+                q1,
+                tp1,
+                {"reduceOnly": True},
+            )
+            if tp2 is not None:
+                exchange.create_order(
+                    symbol,
+                    "LIMIT",
+                    exit_side,
+                    q2,
+                    tp2,
+                    {"reduceOnly": True},
+                )
+            if tp3 is not None:
+                exchange.create_order(
+                    symbol,
+                    "TAKE_PROFIT_MARKET",
+                    exit_side,
+                    q3,
+                    None,
+                    {"reduceOnly": True, "stopPrice": tp3},
+                )
     except OperationRejected as e:  # pragma: no cover - depends on exchange state
         if getattr(e, "code", None) == -4045 or "max stop order" in str(e).lower():
             logger.warning(
@@ -305,9 +351,12 @@ def run(run_live: bool = False, limit: int = 30, ex=None) -> Dict[str, Any]:
                 continue
             ccxt_sym = to_ccxt_symbol(pair)
             side = pos.get("side")
-            tp1 = pos.get("tp")
+            qty_total = pos.get("qty")
+            tp1 = pos.get("tp1") or pos.get("tp")
+            tp2 = pos.get("tp2")
+            tp3 = pos.get("tp3")
             try:
-                _place_sl_tp(ex, ccxt_sym, side, None, sl, tp1)
+                _place_sl_tp(ex, ccxt_sym, side, qty_total, sl, tp1, tp2, tp3)
                 moved_sl.append({"pair": pair, "sl": sl})
             except Exception as e:
                 logger.warning("move_sl error for %s: %s", pair, e)
@@ -352,6 +401,8 @@ def run(run_live: bool = False, limit: int = 30, ex=None) -> Dict[str, Any]:
             entry = c.get("entry")
             sl = c.get("sl")
             tp1 = c.get("tp1")
+            tp2 = c.get("tp2")
+            tp3 = c.get("tp3")
             qty = c.get("qty")
             if (
                 side not in ("buy", "sell")
@@ -378,6 +429,8 @@ def run(run_live: bool = False, limit: int = 30, ex=None) -> Dict[str, Any]:
                             "qty": qty,
                             "sl": sl,
                             "tp1": tp1,
+                            "tp2": tp2,
+                            "tp3": tp3,
                             "expiry": expiry_sec,
                             "ts": time.time(),
                         }
@@ -391,6 +444,8 @@ def run(run_live: bool = False, limit: int = 30, ex=None) -> Dict[str, Any]:
                         "entry": entry,
                         "sl": sl,
                         "tp1": tp1,
+                        "tp2": tp2,
+                        "tp3": tp3,
                         "qty": qty,
                         "entry_id": entry_order.get("id"),
                         "expiry": expiry_min,
@@ -609,6 +664,8 @@ def add_sl_tp_from_json(exchange):
         qty = data.get("qty")
         sl = data.get("sl")
         tp1 = data.get("tp1")
+        tp2 = data.get("tp2")
+        tp3 = data.get("tp3")
         if not (pair and order_id and side and qty and sl and tp1):
             continue
         ccxt_sym = to_ccxt_symbol(pair)
@@ -620,7 +677,7 @@ def add_sl_tp_from_json(exchange):
         status = (o.get("status") or "").lower()
         if status != "closed":
             continue
-        _place_sl_tp(exchange, ccxt_sym, side, qty, sl, tp1)
+        _place_sl_tp(exchange, ccxt_sym, side, qty, sl, tp1, tp2, tp3)
         try:
             fp.unlink()
         except Exception as e:

--- a/tests/test_trading_utils.py
+++ b/tests/test_trading_utils.py
@@ -22,7 +22,7 @@ def test_to_ccxt_symbol_with_exchange_markets():
 def test_parse_mini_actions_handles_close():
     text = (
         "{"
-        '"coins":[{"pair":"BTCUSDT","entry":1,"sl":0.9,"tp":1.05,'
+        '"coins":[{"pair":"BTCUSDT","entry":1,"sl":0.9,"tp1":1.05,"tp2":1.1,"tp3":1.2,'
         '"risk":0.1}],'
         '"close":[{"pair":"ETHUSDT"}],'
         '"move_sl":[{"pair":"XRPUSDT","sl":0.95}],'
@@ -32,6 +32,8 @@ def test_parse_mini_actions_handles_close():
     res = trading_utils.parse_mini_actions(text)
     assert res["coins"] and res["coins"][0]["pair"] == "BTCUSDT"
     assert res["coins"][0]["tp1"] == 1.05
+    assert res["coins"][0]["tp2"] == 1.1
+    assert res["coins"][0]["tp3"] == 1.2
     assert res["coins"][0]["risk"] == 0.1
     assert "expiry" not in res["coins"][0]
     assert res["close"] == [{"pair": "ETHUSDT"}]
@@ -52,10 +54,19 @@ def test_enrich_tp_qty_keeps_tp1(monkeypatch):
     )
     monkeypatch.setattr(trading_utils, "infer_side", lambda entry, sl, tp1: "buy")
     acts = [
-        {"pair": "BTCUSDT", "entry": 100, "sl": 90, "tp1": 110}
+        {
+            "pair": "BTCUSDT",
+            "entry": 100,
+            "sl": 90,
+            "tp1": 110,
+            "tp2": 120,
+            "tp3": 130,
+        }
     ]
     res = trading_utils.enrich_tp_qty(ex, acts, capital=1000)
     assert res[0]["tp1"] == 110
+    assert res[0]["tp2"] == 120
+    assert res[0]["tp3"] == 130
 
 
 def test_enrich_tp_qty_skips_when_tp_missing(monkeypatch):

--- a/trading_utils.py
+++ b/trading_utils.py
@@ -36,6 +36,8 @@ def parse_mini_actions(text: str) -> Dict[str, Any]:
         entry = item.get("entry")
         sl = item.get("sl")
         tp1 = item.get("tp1") if item.get("tp1") is not None else item.get("tp")
+        tp2 = item.get("tp2")
+        tp3 = item.get("tp3")
         risk = item.get("risk")
         conf = item.get("conf")
         rr = item.get("rr")
@@ -43,6 +45,8 @@ def parse_mini_actions(text: str) -> Dict[str, Any]:
             entry = float(entry) if entry is not None else None
             sl = float(sl) if sl is not None else None
             tp1 = float(tp1) if tp1 not in (None, "") else None
+            tp2 = float(tp2) if tp2 not in (None, "") else None
+            tp3 = float(tp3) if tp3 not in (None, "") else None
             risk = float(risk) if risk not in (None, "") else None
             conf = float(conf) if conf not in (None, "") else None
             rr = float(rr) if rr not in (None, "") else None
@@ -58,12 +62,24 @@ def parse_mini_actions(text: str) -> Dict[str, Any]:
             or (side == "sell" and tp1 >= entry)
         ):
             continue
+        if tp2 is not None and (
+            (side == "buy" and tp2 <= entry)
+            or (side == "sell" and tp2 >= entry)
+        ):
+            tp2 = None
+        if tp3 is not None and (
+            (side == "buy" and tp3 <= entry)
+            or (side == "sell" and tp3 >= entry)
+        ):
+            tp3 = None
         coins.append(
             {
                 "pair": pair,
                 "entry": entry,
                 "sl": sl,
                 "tp1": tp1,
+                "tp2": tp2,
+                "tp3": tp3,
                 "risk": risk,
                 "conf": conf,
                 "rr": rr,
@@ -222,6 +238,8 @@ def enrich_tp_qty(exchange, acts: List[Dict[str, Any]], capital: float) -> List[
         entry = a.get("entry")
         sl = a.get("sl")
         tp1 = a.get("tp1")
+        tp2 = a.get("tp2")
+        tp3 = a.get("tp3")
         risk = a.get("risk")
         if not (
             isinstance(entry, (int, float))
@@ -230,6 +248,10 @@ def enrich_tp_qty(exchange, acts: List[Dict[str, Any]], capital: float) -> List[
         ):
             continue
         a["tp1"] = rfloat(tp1, 8)
+        if isinstance(tp2, (int, float)):
+            a["tp2"] = rfloat(tp2, 8)
+        if isinstance(tp3, (int, float)):
+            a["tp3"] = rfloat(tp3, 8)
         rf = float(risk) if isinstance(risk, (int, float)) and risk > 0 else 0.005
         ccxt_sym = to_ccxt_symbol(a["pair"])
         step = qty_step(exchange, ccxt_sym)


### PR DESCRIPTION
## Summary
- parse optional tp2 and tp3 values from model output
- place three take-profit orders split 30/50/20 percent with tp1 & tp2 as limit orders and tp3 as market close
- track multiple take-profit levels in position snapshots

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b469c2f1588323b1ad574f9cc065f0