### PR TITLE
Include closePosition orders in position snapshot

### DIFF
--- a/positions.py
+++ b/positions.py
@@ -90,7 +90,10 @@ def positions_snapshot(exchange) -> List[Dict]:
         stop_orders = [
             o
             for o in orders
-            if o.get("reduceOnly")
+            if (
+                o.get("reduceOnly")
+                or (o.get("info") or {}).get("closePosition")
+            )
             and (
                 o.get("stopPrice")
                 or (o.get("info") or {}).get("stopPrice")

--- a/tests/test_positions.py
+++ b/tests/test_positions.py
@@ -1,0 +1,31 @@
+from positions import positions_snapshot
+
+
+class DummyExchange:
+    def fetch_positions(self):
+        return [
+            {
+                "symbol": "BTC/USDT:USDT",
+                "contracts": 1,
+                "entryPrice": 100,
+                "unrealizedPnl": 5,
+            }
+        ]
+
+    def fetch_open_orders(self, symbol):
+        return [
+            {"info": {"closePosition": True, "stopPrice": 90}},
+            {"info": {"closePosition": True, "stopPrice": 110}},
+        ]
+
+
+def test_positions_snapshot_includes_close_position_orders():
+    ex = DummyExchange()
+    res = positions_snapshot(ex)
+    assert len(res) == 1
+    pos = res[0]
+    assert pos["pair"] == "BTCUSDT"
+    assert pos["qty"] == 1.0
+    assert pos["sl"] == 90.0
+    assert pos["tp"] == 110.0
+    assert pos["tp1"] == 110.0


### PR DESCRIPTION
## Summary
- Consider both `reduceOnly` and `closePosition` when parsing stop orders so stop-loss/take-profit levels appear for positions
- Add regression test ensuring `closePosition` orders are included in position snapshots

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b46e240a348323959baeefbdd38aa0