### PR TITLE
Ensure position snapshot includes sl field

### DIFF
--- a/positions.py
+++ b/positions.py
@@ -136,21 +136,20 @@ def positions_snapshot(exchange) -> List[Dict]:
                     tp2 = rfloat(tp_sorted[1])
                 if len(tp_sorted) > 2:
                     tp3 = rfloat(tp_sorted[2])
-        out.append(
-            drop_empty(
-                {
-                    "pair": pair,
-                    "side": side,
-                    "entry": rfloat(entry_price),
-                    "qty": rfloat(qty),
-                    "sl": sl,
-                    "tp": tp1,
-                    "tp1": tp1,
-                    "tp2": tp2,
-                    "tp3": tp3,
-                    "pnl": pnl,
-                }
-            )
+        data = drop_empty(
+            {
+                "pair": pair,
+                "side": side,
+                "entry": rfloat(entry_price),
+                "qty": rfloat(qty),
+                "tp": tp1,
+                "tp1": tp1,
+                "tp2": tp2,
+                "tp3": tp3,
+                "pnl": pnl,
+            }
         )
+        data["sl"] = rfloat(sl) if sl is not None else None
+        out.append(data)
     return out
 

--- a/tests/test_positions.py
+++ b/tests/test_positions.py
@@ -29,3 +29,27 @@ def test_positions_snapshot_includes_close_position_orders():
     assert pos["sl"] == 90.0
     assert pos["tp"] == 110.0
     assert pos["tp1"] == 110.0
+
+
+class DummyExchangeNoStops:
+    def fetch_positions(self):
+        return [
+            {
+                "symbol": "BTC/USDT:USDT",
+                "contracts": 1,
+                "entryPrice": 100,
+                "unrealizedPnl": 5,
+            }
+        ]
+
+    def fetch_open_orders(self, symbol):
+        return []
+
+
+def test_positions_snapshot_includes_sl_key_without_stop_orders():
+    ex = DummyExchangeNoStops()
+    res = positions_snapshot(ex)
+    assert len(res) == 1
+    pos = res[0]
+    assert "sl" in pos
+    assert pos["sl"] is None


### PR DESCRIPTION
## Summary
- Preserve `sl` field in `positions_snapshot` even when no stop-loss orders exist
- Test `positions_snapshot` returns `sl` key with `None` when no stop orders

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b47307a89483238bd3bb89054ffb11