### PR TITLE
Improve position field parsing

### DIFF
--- a/positions.py
+++ b/positions.py
@@ -29,11 +29,22 @@ def get_open_position_pairs(exchange) -> Set[str]:
         for p in positions or []:
             sym = p.get("symbol") or (p.get("info") or {}).get("symbol")
             pair = _norm_pair_from_symbol(sym)
-            amt = p.get("contracts")
+            amt = (
+                p.get("contracts")
+                or p.get("amount")
+                or p.get("size")
+                or p.get("qty")
+                or p.get("quantity")
+            )
             if amt is None:
-                amt = p.get("amount")
-            if amt is None:
-                amt = (p.get("info") or {}).get("positionAmt", 0)
+                info = p.get("info") or {}
+                amt = (
+                    info.get("positionAmt")
+                    or info.get("size")
+                    or info.get("qty")
+                    or info.get("quantity")
+                    or 0
+                )
             try:
                 if abs(float(amt)) > 0:
                     out.add(pair)
@@ -58,12 +69,30 @@ def positions_snapshot(exchange) -> List[Dict]:
     for p in positions or []:
         sym = p.get("symbol") or (p.get("info") or {}).get("symbol")
         pair = _norm_pair_from_symbol(sym)
-        amt = p.get("contracts")
+        amt = (
+            p.get("contracts")
+            or p.get("amount")
+            or p.get("size")
+            or p.get("qty")
+            or p.get("quantity")
+        )
         if amt is None:
-            amt = p.get("amount")
-        if amt is None:
-            amt = (p.get("info") or {}).get("positionAmt")
-        entry = p.get("entryPrice") or (p.get("info") or {}).get("entryPrice")
+            info = p.get("info") or {}
+            amt = (
+                info.get("positionAmt")
+                or info.get("size")
+                or info.get("qty")
+                or info.get("quantity")
+            )
+        entry = (
+            p.get("entryPrice")
+            or p.get("avgPrice")
+            or p.get("averagePrice")
+            or p.get("meanPrice")
+            or (p.get("info") or {}).get("entryPrice")
+            or (p.get("info") or {}).get("avgEntryPrice")
+            or (p.get("info") or {}).get("avgPrice")
+        )
         try:
             amt_val = float(amt)
             entry_price = float(entry)
@@ -93,6 +122,7 @@ def positions_snapshot(exchange) -> List[Dict]:
                 o.get("stopPrice")
                 or info.get("stopPrice")
                 or info.get("triggerPrice")
+                or info.get("orderPrice")
                 or o.get("price")
                 or info.get("price")
             )
@@ -106,8 +136,12 @@ def positions_snapshot(exchange) -> List[Dict]:
             for o in orders
             if (
                 o.get("reduceOnly")
+                or o.get("reduce_only")
                 or (o.get("info") or {}).get("reduceOnly")
+                or (o.get("info") or {}).get("reduce_only")
                 or (o.get("info") or {}).get("closePosition")
+                or (o.get("info") or {}).get("close_on_trigger")
+                or (o.get("info") or {}).get("closeOnTrigger")
             )
             and _extract_price(o) is not None
         ]

--- a/tests/test_positions.py
+++ b/tests/test_positions.py
@@ -80,3 +80,43 @@ def test_positions_snapshot_handles_trigger_price():
     pos = res[0]
     assert pos["sl"] == 90.0
     assert pos["tp"] == 110.0
+
+
+class DummyExchangeAltFields:
+    def fetch_positions(self):
+        return [
+            {
+                "symbol": "ETH/USDT:USDT",
+                "size": 2,
+                "avgPrice": "2000",
+                "unrealizedPnl": 10,
+            }
+        ]
+
+    def fetch_open_orders(self, symbol):
+        return []
+
+
+def test_positions_snapshot_handles_size_and_avgprice():
+    ex = DummyExchangeAltFields()
+    res = positions_snapshot(ex)
+    assert len(res) == 1
+    pos = res[0]
+    assert pos["pair"] == "ETHUSDT"
+    assert pos["qty"] == 2.0
+    assert pos["entry"] == 2000.0
+
+
+class DummyExchangePairsAlt:
+    def fetch_positions(self):
+        return [
+            {"symbol": "ETH/USDT:USDT", "size": 1}
+        ]
+
+
+def test_get_open_position_pairs_supports_size():
+    from positions import get_open_position_pairs
+
+    ex = DummyExchangePairsAlt()
+    res = get_open_position_pairs(ex)
+    assert res == {"ETHUSDT"}


### PR DESCRIPTION
## Summary
- handle alt amount and entry price fields for positions
- recognize additional reduce-only flags and order price fields
- test alt position fields and get_open_position_pairs support

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b47c5b1aac832399bb93a42fd02bfc