### PR TITLE
Handle closePosition flags for stop order detection

### DIFF
--- a/positions.py
+++ b/positions.py
@@ -137,6 +137,8 @@ def positions_snapshot(exchange) -> List[Dict]:
             if (
                 o.get("reduceOnly")
                 or o.get("reduce_only")
+                or o.get("closePosition")
+                or o.get("close_position")
                 or (o.get("info") or {}).get("reduceOnly")
                 or (o.get("info") or {}).get("reduce_only")
                 or (o.get("info") or {}).get("closePosition")


### PR DESCRIPTION
## Summary
- Detect top-level `closePosition` and `close_position` flags when collecting stop orders

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b47eb783ec8323a9c41f8fc9076098