### PR TITLE
Handle stop_market triggerPrice orders

### DIFF
--- a/futures_gpt_orchestrator_full.py
+++ b/futures_gpt_orchestrator_full.py
@@ -551,6 +551,8 @@ def cancel_unpositioned_stops(exchange) -> None:
             if not (
                 o.get("stopPrice")
                 or info.get("stopPrice")
+                or o.get("triggerPrice")
+                or info.get("triggerPrice")
                 or (o.get("type") or "").lower().startswith("take")
                 or (o.get("type") or "").lower().startswith("stop")
             ):
@@ -745,6 +747,8 @@ def move_sl_to_entry(exchange):
             and (
                 o.get("stopPrice")
                 or (o.get("info") or {}).get("stopPrice")
+                or o.get("triggerPrice")
+                or (o.get("info") or {}).get("triggerPrice")
                 or o.get("price")
             )
         ]

--- a/positions.py
+++ b/positions.py
@@ -121,6 +121,7 @@ def positions_snapshot(exchange) -> List[Dict]:
             price = (
                 o.get("stopPrice")
                 or info.get("stopPrice")
+                or o.get("triggerPrice")
                 or info.get("triggerPrice")
                 or info.get("orderPrice")
                 or o.get("price")

--- a/tests/test_positions.py
+++ b/tests/test_positions.py
@@ -82,6 +82,33 @@ def test_positions_snapshot_handles_trigger_price():
     assert pos["tp"] == 110.0
 
 
+class DummyExchangeTopTrigger:
+    def fetch_positions(self):
+        return [
+            {
+                "symbol": "BTC/USDT:USDT",
+                "contracts": 1,
+                "entryPrice": 100,
+                "unrealizedPnl": 5,
+            }
+        ]
+
+    def fetch_open_orders(self, symbol):
+        return [
+            {"triggerPrice": 90, "info": {"closePosition": True}},
+            {"triggerPrice": 110, "info": {"closePosition": True}},
+        ]
+
+
+def test_positions_snapshot_handles_top_level_trigger_price():
+    ex = DummyExchangeTopTrigger()
+    res = positions_snapshot(ex)
+    assert len(res) == 1
+    pos = res[0]
+    assert pos["sl"] == 90.0
+    assert pos["tp"] == 110.0
+
+
 class DummyExchangeAltFields:
     def fetch_positions(self):
         return [


### PR DESCRIPTION
## Summary
- Recognize top-level `triggerPrice` values when extracting stop-loss and take-profit prices
- Ensure stop-loss shift logic and orphaned stop cleanup account for `triggerPrice`
- Add tests covering triggerPrice in stop orders

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4805e7cbc8323b0ade9c194eb5da0