### PR TITLE
refactor: simplify to single take profit

### DIFF
--- a/positions.py
+++ b/positions.py
@@ -104,9 +104,7 @@ def positions_snapshot(exchange) -> List[Dict]:
         side = "buy" if amt_val > 0 else "sell"
         qty = abs(amt_val)
         sl = None
-        tp1 = None
-        tp2 = None
-        tp3 = None
+        tp = None
         pnl = p.get("unrealizedPnl") or (p.get("info") or {}).get(
             "unrealizedProfit"
         )
@@ -171,22 +169,17 @@ def positions_snapshot(exchange) -> List[Dict]:
             if sl_prices:
                 sl = rfloat(min(sl_prices) if side == "buy" else max(sl_prices))
             if tp_prices:
-                tp_sorted = sorted(tp_prices) if side == "buy" else sorted(tp_prices, reverse=True)
-                tp1 = rfloat(tp_sorted[0])
-                if len(tp_sorted) > 1:
-                    tp2 = rfloat(tp_sorted[1])
-                if len(tp_sorted) > 2:
-                    tp3 = rfloat(tp_sorted[2])
+                tp_sorted = (
+                    sorted(tp_prices) if side == "buy" else sorted(tp_prices, reverse=True)
+                )
+                tp = rfloat(tp_sorted[0])
         data = drop_empty(
             {
                 "pair": pair,
                 "side": side,
                 "entry": rfloat(entry_price),
                 "qty": rfloat(qty),
-                "tp": tp1,
-                "tp1": tp1,
-                "tp2": tp2,
-                "tp3": tp3,
+                "tp": tp,
                 "pnl": pnl,
             }
         )

--- a/prompts.py
+++ b/prompts.py
@@ -7,7 +7,7 @@ PROMPT_SYS_MINI = (
     "- OHLCV 200 nến cho mỗi symbol USDT ở 1H/4H/1D. Dùng tất cả phương pháp có thể như AT, mô hình nến, mô hình sóng .. \n"
     "- Vị thế hiện tại: {pair, side, entry, sl, tp, pnl}.\n"
     "- Tuỳ chọn: derivatives (funding, OI, basis), order flow (CVD/delta, liquidations), volume profile (POC/HVN/LVN), volatility (ATR/HV/IV), on-chain/sentiment, sự kiện. Nếu thiếu, bỏ qua (KHÔNG trừ điểm, KHÔNG suy diễn).\n"
-    "Trả về DUY NHẤT JSON: {\"coins\":[{\"pair\":\"SYMBOLUSDT\",\"entry\":0.00,\"sl\":0.00,\"tp1\":0.00,\"tp2\":0.00,\"tp3\":0.00,\"conf\":0.0,\"rr\":0,\"reason\":""}],\"close\":[{\"pair\":\"SYMBOLUSDT\"}],\"move_sl\":[{\"pair\":\"SYMBOLUSDT\",\"sl\":0.0}],\"close_partial\":[{\"pair\":\"SYMBOLUSDT\",\"pct\":50}],\"close_all\":false}.\n"
+    "Trả về DUY NHẤT JSON: {\"coins\":[{\"pair\":\"SYMBOLUSDT\",\"entry\":0.00,\"sl\":0.00,\"tp\":0.00,\"conf\":0.0,\"rr\":0,\"reason\":""}],\"close\":[{\"pair\":\"SYMBOLUSDT\"}],\"move_sl\":[{\"pair\":\"SYMBOLUSDT\",\"sl\":0.0}],\"close_partial\":[{\"pair\":\"SYMBOLUSDT\",\"pct\":50}],\"close_all\":false}.\n"
     "Yêu cầu : + Tham khảo theo BTC . + CONF ≥ 7.0 và RR ≥ 1.8 . + SL TP theo khung 1h."
 )
 

--- a/tests/test_positions.py
+++ b/tests/test_positions.py
@@ -28,7 +28,6 @@ def test_positions_snapshot_includes_close_position_orders():
     assert pos["qty"] == 1.0
     assert pos["sl"] == 90.0
     assert pos["tp"] == 110.0
-    assert pos["tp1"] == 110.0
 
 
 class DummyExchangeNoStops:

--- a/trading_utils.py
+++ b/trading_utils.py
@@ -37,18 +37,14 @@ def parse_mini_actions(text: str) -> Dict[str, Any]:
             continue
         entry = item.get("entry")
         sl = item.get("sl")
-        tp1 = item.get("tp1") if item.get("tp1") is not None else item.get("tp")
-        tp2 = item.get("tp2")
-        tp3 = item.get("tp3")
+        tp = item.get("tp") if item.get("tp") is not None else item.get("tp1")
         risk = item.get("risk")
         conf = item.get("conf")
         rr = item.get("rr")
         try:
             entry = float(entry) if entry is not None else None
             sl = float(sl) if sl is not None else None
-            tp1 = float(tp1) if tp1 not in (None, "") else None
-            tp2 = float(tp2) if tp2 not in (None, "") else None
-            tp3 = float(tp3) if tp3 not in (None, "") else None
+            tp = float(tp) if tp not in (None, "") else None
             risk = float(risk) if risk not in (None, "") else None
             conf = float(conf) if conf not in (None, "") else None
             rr = float(rr) if rr not in (None, "") else None
@@ -59,29 +55,17 @@ def parse_mini_actions(text: str) -> Dict[str, Any]:
         if risk is not None and not (0 < risk < 1):
             continue
         side = "buy" if entry > sl else "sell"
-        if tp1 is not None and (
-            (side == "buy" and tp1 <= entry)
-            or (side == "sell" and tp1 >= entry)
+        if tp is not None and (
+            (side == "buy" and tp <= entry)
+            or (side == "sell" and tp >= entry)
         ):
             continue
-        if tp2 is not None and (
-            (side == "buy" and tp2 <= entry)
-            or (side == "sell" and tp2 >= entry)
-        ):
-            tp2 = None
-        if tp3 is not None and (
-            (side == "buy" and tp3 <= entry)
-            or (side == "sell" and tp3 >= entry)
-        ):
-            tp3 = None
         coins.append(
             {
                 "pair": pair,
                 "entry": entry,
                 "sl": sl,
-                "tp1": tp1,
-                "tp2": tp2,
-                "tp3": tp3,
+                "tp": tp,
                 "risk": risk,
                 "conf": conf,
                 "rr": rr,
@@ -239,21 +223,15 @@ def enrich_tp_qty(exchange, acts: List[Dict[str, Any]], capital: float) -> List[
     for a in acts:
         entry = a.get("entry")
         sl = a.get("sl")
-        tp1 = a.get("tp1")
-        tp2 = a.get("tp2")
-        tp3 = a.get("tp3")
+        tp = a.get("tp") if a.get("tp") is not None else a.get("tp1")
         risk = a.get("risk")
         if not (
             isinstance(entry, (int, float))
             and isinstance(sl, (int, float))
-            and isinstance(tp1, (int, float))
+            and isinstance(tp, (int, float))
         ):
             continue
-        a["tp1"] = rfloat(tp1, 8)
-        if isinstance(tp2, (int, float)):
-            a["tp2"] = rfloat(tp2, 8)
-        if isinstance(tp3, (int, float)):
-            a["tp3"] = rfloat(tp3, 8)
+        a["tp"] = rfloat(tp, 8)
         rf = (
             float(risk) if isinstance(risk, (int, float)) and risk > 0 else DEFAULT_RISK_FRAC
         )
@@ -271,7 +249,7 @@ def enrich_tp_qty(exchange, acts: List[Dict[str, Any]], capital: float) -> List[
             continue  # bỏ qua nếu khối lượng bằng 0
         a["qty"] = rfloat(qty, 8)
         a["risk"] = rfloat(rf, 6)
-        side = infer_side(float(entry), float(sl), float(tp1))
+        side = infer_side(float(entry), float(sl), float(tp))
         if side in {"buy", "sell"}:
             a["side"] = side
             out.append(a)


### PR DESCRIPTION
## Summary
- switch trade parsing and quantity enrichment to use a single `tp`
- update order placement and position snapshot to manage one take-profit level
- adjust prompts and tests for single `tp`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b7b5ccb1088323a18cd92023348a7f