### PR TITLE
Mask API key in event logs

### DIFF
--- a/events.py
+++ b/events.py
@@ -4,10 +4,22 @@ from datetime import datetime, timedelta, timezone
 from typing import Dict, List
 
 import requests
+from urllib.parse import parse_qsl, urlsplit, urlunsplit
 
 logger = logging.getLogger(__name__)
 
 API_URL = "https://financialmodelingprep.com/api/v3/economic_calendar"
+
+
+def _sanitize_url(url: str) -> str:
+    if not url:
+        return url
+    parts = list(urlsplit(url))
+    query = dict(parse_qsl(parts[3]))
+    if "apikey" in query:
+        query["apikey"] = "***"
+    parts[3] = "&".join(f"{k}={v}" for k, v in query.items())
+    return urlunsplit(parts)
 
 
 def event_snapshot(days: int = 1) -> List[Dict]:
@@ -32,6 +44,11 @@ def event_snapshot(days: int = 1) -> List[Dict]:
         resp = requests.get(API_URL, params=params, timeout=10)
         resp.raise_for_status()
         data = resp.json()
+    except requests.RequestException as e:
+        url = _sanitize_url(getattr(e.request, "url", ""))
+        status = getattr(e.response, "status_code", "")
+        logger.warning("event_snapshot request failed: %s %s", status, url)
+        return []
     except Exception as e:  # noqa: BLE001
         logger.warning("event_snapshot request failed: %s", e)
         return []

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,0 +1,25 @@
+import logging
+import os
+from unittest.mock import patch
+
+import events
+import requests
+
+
+def test_event_snapshot_masks_api_key_on_http_error(caplog):
+    class FakeResp:
+        def raise_for_status(self):
+            request = requests.Request(
+                "GET",
+                "https://financialmodelingprep.com/api/v3/economic_calendar?from=2025-09-03&to=2025-09-04&apikey=SECRET",
+            ).prepare()
+            response = requests.Response()
+            response.status_code = 403
+            raise requests.HTTPError("403 Client Error", request=request, response=response)
+
+    with patch("events.requests.get", return_value=FakeResp()):
+        with patch.dict(os.environ, {"FMP_API_KEY": "SECRET"}):
+            caplog.set_level(logging.WARNING)
+            events.event_snapshot()
+    assert "SECRET" not in caplog.text
+    assert "apikey=***" in caplog.text


### PR DESCRIPTION
## Summary
- Sanitize FinancialModelingPrep URLs to hide API keys in logs
- Log HTTP errors without leaking secrets
- Add regression test ensuring API key masking

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b7fd434920832392da90cdee5c610e