### PR TITLE
Use Trading Economics for economic events

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,13 @@ Specify the trading pairs to analyse via the `COIN_PAIRS` variable in your `.env
 ### Economic events API
 
 Upcoming macroeconomic events are fetched from the
-[Financial Modeling Prep](https://financialmodelingprep.com/developer/docs/economic-calendar-api/)
-API. Set the `FMP_API_KEY` environment variable with your API token to
-enable event retrieval:
+[Trading Economics](https://tradingeconomics.com/api/) calendar API. Set
+the `TE_API_KEY` environment variable with your API token to enable
+event retrieval. If the variable is not set, the public `guest:guest`
+key is used (subject to rate limits):
 
 ```env
-FMP_API_KEY=your_api_key_here
+TE_API_KEY=your_api_key_here
 ```
 
 If the key is missing or the request fails, the bot will continue

--- a/events.py
+++ b/events.py
@@ -8,7 +8,9 @@ from urllib.parse import parse_qsl, urlsplit, urlunsplit
 
 logger = logging.getLogger(__name__)
 
-API_URL = "https://financialmodelingprep.com/api/v3/economic_calendar"
+# Trading Economics calendar endpoint. Country "All" is included in the
+# base URL; start and end dates are appended as path segments.
+API_URL = "https://api.tradingeconomics.com/calendar/country/All"
 
 
 def _sanitize_url(url: str) -> str:
@@ -16,32 +18,33 @@ def _sanitize_url(url: str) -> str:
         return url
     parts = list(urlsplit(url))
     query = dict(parse_qsl(parts[3]))
-    if "apikey" in query:
-        query["apikey"] = "***"
+    for key in ("apikey", "c"):
+        if key in query:
+            query[key] = "***"
     parts[3] = "&".join(f"{k}={v}" for k, v in query.items())
     return urlunsplit(parts)
 
 
 def event_snapshot(days: int = 1) -> List[Dict]:
-    """Return upcoming economic events using FinancialModelingPrep API.
+    """Return upcoming economic events using Trading Economics API.
 
-    The function reads ``FMP_API_KEY`` from the environment. On network or
-    parsing errors an empty list is returned and the error is logged.
+    The function reads ``TE_API_KEY`` from the environment. If it is not set,
+    the public ``guest:guest`` key is used and a warning is logged. On network
+    or parsing errors an empty list is returned and the error is logged.
     """
 
-    api_key = os.getenv("FMP_API_KEY")
+    api_key = os.getenv("TE_API_KEY")
     if not api_key:
-        logger.warning("FMP_API_KEY not set")
-        return []
+        logger.warning("TE_API_KEY not set, using guest:guest")
+        api_key = "guest:guest"
 
     now = datetime.now(timezone.utc)
-    params = {
-        "from": now.strftime("%Y-%m-%d"),
-        "to": (now + timedelta(days=days)).strftime("%Y-%m-%d"),
-        "apikey": api_key,
-    }
+    start = now.strftime("%Y-%m-%d")
+    end = (now + timedelta(days=days)).strftime("%Y-%m-%d")
+    params = {"c": api_key, "f": "json"}
+
     try:
-        resp = requests.get(API_URL, params=params, timeout=10)
+        resp = requests.get(f"{API_URL}/{start}/{end}", params=params, timeout=10)
         resp.raise_for_status()
         data = resp.json()
     except requests.RequestException as e:
@@ -58,9 +61,9 @@ def event_snapshot(days: int = 1) -> List[Dict]:
         try:
             events.append(
                 {
-                    "time": item.get("date"),
-                    "title": item.get("event"),
-                    "impact": item.get("impact"),
+                    "time": item.get("Date"),
+                    "title": item.get("Event"),
+                    "impact": item.get("Importance"),
                 }
             )
         except Exception as e:  # noqa: BLE001

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -11,15 +11,15 @@ def test_event_snapshot_masks_api_key_on_http_error(caplog):
         def raise_for_status(self):
             request = requests.Request(
                 "GET",
-                "https://financialmodelingprep.com/api/v3/economic_calendar?from=2025-09-03&to=2025-09-04&apikey=SECRET",
+                "https://api.tradingeconomics.com/calendar/country/All/2025-09-03/2025-09-04?c=SECRET&f=json",
             ).prepare()
             response = requests.Response()
             response.status_code = 403
             raise requests.HTTPError("403 Client Error", request=request, response=response)
 
     with patch("events.requests.get", return_value=FakeResp()):
-        with patch.dict(os.environ, {"FMP_API_KEY": "SECRET"}):
+        with patch.dict(os.environ, {"TE_API_KEY": "SECRET"}):
             caplog.set_level(logging.WARNING)
             events.event_snapshot()
     assert "SECRET" not in caplog.text
-    assert "apikey=***" in caplog.text
+    assert "c=***" in caplog.text


### PR DESCRIPTION
## Summary
- switch economic events API from Financial Modeling Prep to Trading Economics
- default to guest API key and sanitize `c` query parameter
- update unit test and documentation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b800f38bec83239d40c05fb4704e9b