### PR TITLE
feat: add m15 prompt and payload builder

### DIFF
--- a/payload_builder.py
+++ b/payload_builder.py
@@ -133,6 +133,38 @@ def build_snap(df: pd.DataFrame) -> Dict:
     }
 
 
+def build_m15_payload(exchange, symbol: str) -> Dict:
+    """Return payload with 100x15m candles plus 1h/4h ATR."""
+
+    df_15m = fetch_ohlcv_df(exchange, symbol, "15m", 100)
+    df_1h = fetch_ohlcv_df(exchange, symbol, "1h", 50)
+    df_4h = fetch_ohlcv_df(exchange, symbol, "4h", 50)
+
+    ind_1h = add_indicators(df_1h)
+    ind_4h = add_indicators(df_4h)
+
+    atr_1h = rprice(ind_1h["atr14"].iloc[-1])
+    atr_4h = rprice(ind_4h["atr14"].iloc[-1])
+
+    data_15m = [
+        {
+            "time": idx.strftime("%Y-%m-%d %H:%M"),
+            "open": float(row.open),
+            "high": float(row.high),
+            "low": float(row.low),
+            "close": float(row.close),
+            "volume": float(row.volume),
+        }
+        for idx, row in df_15m.tail(100).iterrows()
+    ]
+
+    return {
+        "atr_1h": atr_1h,
+        "atr_4h": atr_4h,
+        "data_15m": data_15m,
+    }
+
+
 def coin_payload(exchange, symbol: str) -> Dict:
     """Build payload for a single symbol with thread-safe caching."""
 

--- a/prompts.py
+++ b/prompts.py
@@ -22,3 +22,52 @@ def build_prompts_mini(payload_kept):
         "system": PROMPT_SYS_MINI,
         "user": PROMPT_USER_MINI.replace("{payload}", dumps_min(payload_kept)),
     }
+
+
+# --- M15 analysis prompt ---------------------------------------------------
+
+PROMPT_SYS_M15 = (
+    "Bạn là chuyên gia trading. Hãy phân tích dữ liệu dưới đây theo các bước:\n"
+    " \n"
+    "1. Đánh giá biến động tổng quan dựa vào ATR 1H và 4H đã cho.\n"
+    "2. Kiểm tra dữ liệu 15m (100 nến OHLCV):\n"
+    "   - Xác định tín hiệu từ EMA 7 và EMA 25 (cắt lên, cắt xuống, vị trí so với nhau).\n"
+    "   - Nhận diện các mô hình nến đảo chiều hoặc tiếp diễn (pin bar, engulfing, doji, inside bar, morning star, evening star…).\n"
+    "   - Phát hiện breakout và retest quan trọng.\n"
+    "   - Phân tích volume: breakout mạnh hay trap.\n"
+    "   - Tính ATR 15m để xác định biến động.\n"
+    "3. Kết hợp các yếu tố trên với ATR 1H/4H để đưa ra khuyến nghị: Buy / Sell / Không vào lệnh.\n"
+    "4. Đề xuất Entry, Stop Loss, Take Profit (dựa trên ATR hoặc swing high/low).\n"
+    "5. Đưa ra nhận xét về rủi ro và độ tin cậy của kèo.\n"
+    " \n"
+    "Hãy trả lời chi tiết, giải thích rõ từng bước."
+)
+
+PROMPT_USER_M15 = (
+    "Dữ liệu phân tích:\n\n"
+    "ATR 4H: {atr_4h}\n"
+    "ATR 1H: {atr_1h}\n\n"
+    "Dữ liệu 100 nến 15m (OHLCV + volume):\n"
+    "{data_15m}\n\n"
+    "Hãy phân tích theo checklist đã mô tả ở trên."
+)
+
+
+def build_prompts_m15(payload):
+    """Return a ready-to-send chat completion body for M15 analysis."""
+
+    data = dumps_min(payload.get("data_15m", []))
+    user = PROMPT_USER_M15.format(
+        atr_4h=payload.get("atr_4h", ""),
+        atr_1h=payload.get("atr_1h", ""),
+        data_15m=data,
+    )
+    return {
+        "model": "gpt-5",
+        "messages": [
+            {"role": "system", "content": PROMPT_SYS_M15},
+            {"role": "user", "content": user},
+        ],
+        "temperature": 0.3,
+    }
+

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -2,7 +2,7 @@ import pathlib
 import sys
 
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
-from prompts import build_prompts_mini  # noqa: E402
+from prompts import build_prompts_mini, build_prompts_m15  # noqa: E402
 from env_utils import dumps_min  # noqa: E402
 
 
@@ -13,4 +13,20 @@ def test_build_prompts_mini_injects_payload():
     assert dumped in pr["user"]
     assert pr["user"].count(dumped) == 1
     assert "{payload}" not in pr["user"]
+
+
+def test_build_prompts_m15_injects_data():
+    payload = {
+        "atr_4h": 1.0,
+        "atr_1h": 0.5,
+        "data_15m": [{"time": "t", "open": 1, "high": 1, "low": 1, "close": 1, "volume": 1}],
+    }
+    pr = build_prompts_m15(payload)
+    dumped = dumps_min(payload["data_15m"])
+    user = pr["messages"][1]["content"]
+    assert dumped in user
+    assert "ATR 4H: 1.0" in user
+    assert "ATR 1H: 0.5" in user
+    assert pr["model"] == "gpt-5"
+    assert pr["temperature"] == 0.3
 


### PR DESCRIPTION
## Summary
- add detailed Vietnamese prompt and payload builder for M15 trading analysis
- support building 15m candle payload with higher timeframe ATR only
- test new prompt and payload utilities

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b85c66193c83239f6e44f0f4706b97