### PR TITLE
Allow rr equality in trading action parsing

### DIFF
--- a/tests/test_trading_utils.py
+++ b/tests/test_trading_utils.py
@@ -53,6 +53,14 @@ def test_parse_mini_actions_filters_conf_rr():
     assert res["coins"] == []
 
 
+def test_parse_mini_actions_allows_equal_rr():
+    text = (
+        '{"coins":[{"pair":"AVAXUSDT","entry":25.28,"sl":24.90,"tp":25.85,"conf":7.5,"rr":1.5}]}'
+    )
+    res = trading_utils.parse_mini_actions(text)
+    assert res["coins"]
+
+
 def test_enrich_tp_qty_keeps_tp(monkeypatch):
     ex = types.SimpleNamespace(
         market=lambda symbol: {"limits": {"leverage": {"max": 100}}, "contractSize": 1}

--- a/trading_utils.py
+++ b/trading_utils.py
@@ -54,7 +54,7 @@ def parse_mini_actions(text: str) -> Dict[str, Any]:
             continue
         if conf is None or conf < MIN_CONF:
             continue
-        if rr is None or rr <= MIN_RR:
+        if rr is None or rr < MIN_RR:
             continue
         side = "buy" if entry > sl else "sell"
         if tp is not None and (


### PR DESCRIPTION
## Summary
- accept trades with risk/reward exactly at the minimum threshold
- add regression test for equal rr parsing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b8755c292c8323937d2126c0e87c93