### PR TITLE
Prevent immediate stop-loss/take-profit triggers

### DIFF
--- a/futures_gpt_orchestrator_full.py
+++ b/futures_gpt_orchestrator_full.py
@@ -43,7 +43,11 @@ from env_utils import (
 from exchange_utils import make_exchange
 from openai_client import extract_content, send_openai
 from payload_builder import build_payload
-from positions import _norm_pair_from_symbol, get_open_position_pairs, positions_snapshot
+from positions import (
+    _norm_pair_from_symbol,
+    get_open_position_pairs,
+    positions_snapshot,
+)
 from prompts import build_prompts_mini
 from trading_utils import (
     enrich_tp_qty,
@@ -128,29 +132,65 @@ def _place_sl_tp(exchange, symbol, side, qty, sl, tp):
             logger.warning("_place_sl_tp cancel_order error for %s: %s", symbol, e)
 
     try:
-        exchange.create_order(
-            symbol,
-            "STOP_MARKET",
-            exit_side,
-            None,
-            None,
-            {**params_close, "stopPrice": sl},
-        )
-        exchange.create_order(
-            symbol,
-            "TAKE_PROFIT_MARKET",
-            exit_side,
-            None,
-            None,
-            {**params_close, "stopPrice": tp},
-        )
-    except OperationRejected as e:  # pragma: no cover - depends on exchange state
-        if getattr(e, "code", None) == -4045 or "max stop order" in str(e).lower():
-            logger.warning(
-                "_place_sl_tp reached max stop order limit for %s: %s", symbol, e
-            )
+        ticker = exchange.fetch_ticker(symbol)
+        price = float(ticker.get("last") or ticker.get("close"))
+    except Exception as e:  # pragma: no cover - network or exchange error
+        logger.warning("_place_sl_tp fetch_ticker error for %s: %s", symbol, e)
+        price = None
+
+    sl_ok = True
+    tp_ok = True
+    if price is not None:
+        if side == "buy":
+            sl_ok = sl < price
+            tp_ok = tp > price
         else:
-            raise
+            sl_ok = sl > price
+            tp_ok = tp < price
+
+    if sl_ok:
+        try:
+            exchange.create_order(
+                symbol,
+                "STOP_MARKET",
+                exit_side,
+                None,
+                None,
+                {**params_close, "stopPrice": sl},
+            )
+        except OperationRejected as e:  # pragma: no cover - depends on exchange state
+            if getattr(e, "code", None) == -4045 or "max stop order" in str(e).lower():
+                logger.warning(
+                    "_place_sl_tp reached max stop order limit for %s: %s", symbol, e
+                )
+            else:
+                raise
+    else:
+        logger.warning(
+            "_place_sl_tp skipping SL for %s price=%s sl=%s", symbol, price, sl
+        )
+
+    if tp_ok:
+        try:
+            exchange.create_order(
+                symbol,
+                "TAKE_PROFIT_MARKET",
+                exit_side,
+                None,
+                None,
+                {**params_close, "stopPrice": tp},
+            )
+        except OperationRejected as e:  # pragma: no cover - depends on exchange state
+            if getattr(e, "code", None) == -4045 or "max stop order" in str(e).lower():
+                logger.warning(
+                    "_place_sl_tp reached max stop order limit for %s: %s", symbol, e
+                )
+            else:
+                raise
+    else:
+        logger.warning(
+            "_place_sl_tp skipping TP for %s price=%s tp=%s", symbol, price, tp
+        )
 
 
 # Default limit increased to 30 to expand the number of coins processed
@@ -266,11 +306,7 @@ def run(run_live: bool = False, limit: int = 30, ex=None) -> Dict[str, Any]:
             sl = c.get("sl")
             tp = c.get("tp")
             qty = c.get("qty")
-            if (
-                side not in ("buy", "sell")
-                or pair in pos_pairs_live
-                or tp is None
-            ):
+            if side not in ("buy", "sell") or pair in pos_pairs_live or tp is None:
                 continue
             ccxt_sym = to_ccxt_symbol(pair)
             cancel_all_orders_for_pair(ex, ccxt_sym, pair)
@@ -355,9 +391,7 @@ def run(run_live: bool = False, limit: int = 30, ex=None) -> Dict[str, Any]:
 def cancel_unpositioned_limits(exchange, max_age_sec: int = 600 * 3):
     """Cancel stale limit orders for pairs without positions and delete their JSON files."""
 
-    logger.info(
-        "Checking for stale limit orders older than %s seconds", max_age_sec
-    )
+    logger.info("Checking for stale limit orders older than %s seconds", max_age_sec)
     try:
         # Suppress CCXT warning when fetching all open orders without a symbol
         exchange.options["warnOnFetchOpenOrdersWithoutSymbol"] = False
@@ -405,9 +439,7 @@ def cancel_unpositioned_limits(exchange, max_age_sec: int = 600 * 3):
                 if fp.exists():
                     fp.unlink()
             except Exception as e:
-                logger.warning(
-                    "cancel_unpositioned_limits unlink error %s: %s", fp, e
-                )
+                logger.warning("cancel_unpositioned_limits unlink error %s: %s", fp, e)
         except Exception as e:
             logger.warning("cancel_unpositioned_limits processing error: %s", e)
             continue
@@ -500,9 +532,7 @@ def cancel_expired_limit_orders(exchange) -> None:
         try:
             fp.unlink()
         except Exception as e:
-            logger.warning(
-                "cancel_expired_limit_orders unlink error %s: %s", fp, e
-            )
+            logger.warning("cancel_expired_limit_orders unlink error %s: %s", fp, e)
 
 
 def remove_unmapped_limit_files(exchange) -> None:
@@ -516,9 +546,7 @@ def remove_unmapped_limit_files(exchange) -> None:
         orders = []
 
     open_pairs = {
-        _norm_pair_from_symbol(
-            o.get("symbol") or (o.get("info") or {}).get("symbol")
-        )
+        _norm_pair_from_symbol(o.get("symbol") or (o.get("info") or {}).get("symbol"))
         for o in orders or []
         if (o.get("type") or "").lower() == "limit"
     }
@@ -564,7 +592,6 @@ def add_sl_tp_from_json(exchange):
             fp.unlink()
         except Exception as e:
             logger.warning("add_sl_tp_from_json unlink error %s: %s", fp, e)
-
 
 
 def _get_position_info(pos):
@@ -644,8 +671,8 @@ def move_sl_to_entry(exchange):
 
 def live_loop(
     limit: int = 30,
-    cancel_interval: int = 600,   # cancel stale orders (10m)
-    add_interval: int = 60,       # SL/TP add (1m)
+    cancel_interval: int = 600,  # cancel stale orders (10m)
+    add_interval: int = 60,  # SL/TP add (1m)
     move_sl_interval: int = 600,  # move SL to entry (10m)
 ):
     """Run orchestrator and maintenance checks on a schedule.
@@ -678,9 +705,7 @@ def live_loop(
         except Exception:
             logger.exception("run_job error")
         finally:
-            logger.info(
-                "Scheduled run job finished in %.2fs", time.time() - start
-            )
+            logger.info("Scheduled run job finished in %.2fs", time.time() - start)
 
     # def cancel_job():
     #     logger.info("Scheduled stale order cancel check")
@@ -697,9 +722,7 @@ def live_loop(
         except Exception:
             logger.exception("limit_job error")
         finally:
-            logger.info(
-                "SL/TP placement check finished in %.2fs", time.time() - start
-            )
+            logger.info("SL/TP placement check finished in %.2fs", time.time() - start)
 
     def expiry_job():
         start = time.time()
@@ -709,9 +732,7 @@ def live_loop(
         except Exception:
             logger.exception("expiry_job error")
         finally:
-            logger.info(
-                "Limit expiry check finished in %.2fs", time.time() - start
-            )
+            logger.info("Limit expiry check finished in %.2fs", time.time() - start)
 
     def move_sl_job():
         logger.info("Scheduled move SL to entry check")
@@ -731,6 +752,7 @@ def live_loop(
     logger.info("Scheduler starting")
     scheduler.start()
 
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--run", action="store_true")
@@ -744,8 +766,5 @@ if __name__ == "__main__":
         logger.info(dumps_min(run(run_live=args.live, limit=args.limit)))
     else:
         logger.info(
-            dumps_min(
-                run(run_live=env_bool("LIVE", False), limit=env_int("LIMIT", 30))
-            )
+            dumps_min(run(run_live=env_bool("LIVE", False), limit=env_int("LIMIT", 30)))
         )
-

--- a/tests/test_futures_gpt_orchestrator_full.py
+++ b/tests/test_futures_gpt_orchestrator_full.py
@@ -61,7 +61,7 @@ def test_run_sends_coins_only(monkeypatch):
 
     def fake_send_openai(system, user, model):
         captured["user"] = user
-        return {"choices": [{"message": {"content": "{\"coins\": []}"}}]}
+        return {"choices": [{"message": {"content": '{"coins": []}'}}]}
 
     monkeypatch.setattr(orch, "send_openai", fake_send_openai)
     monkeypatch.setattr(
@@ -226,7 +226,9 @@ def test_run_closes_positions(monkeypatch):
     monkeypatch.setattr(orch, "get_models", lambda: (None, "MODEL"))
     monkeypatch.setattr(orch, "ts_prefix", lambda: "ts")
     monkeypatch.setattr(orch, "save_text", lambda *a, **k: None)
-    monkeypatch.setattr(orch, "build_payload", lambda ex, limit: {"coins": [{"p": "AAAUSDT"}]})
+    monkeypatch.setattr(
+        orch, "build_payload", lambda ex, limit: {"coins": [{"p": "AAAUSDT"}]}
+    )
     monkeypatch.setattr(orch, "send_openai", lambda *a, **k: {})
     monkeypatch.setattr(orch, "extract_content", lambda r: "")
     monkeypatch.setattr(
@@ -251,6 +253,7 @@ def test_run_closes_positions(monkeypatch):
     ]
     assert res["closed"] == ["BTCUSDT"]
 
+
 def test_run_respects_max_open_positions(monkeypatch):
     class Ex:
         def fetch_balance(self):
@@ -265,7 +268,9 @@ def test_run_respects_max_open_positions(monkeypatch):
     monkeypatch.setattr(orch, "remove_unmapped_limit_files", lambda e: None)
     monkeypatch.setattr(orch, "cancel_unpositioned_stops", lambda e: None)
     monkeypatch.setattr(orch, "env_int", lambda k, d: 10)
-    monkeypatch.setattr(orch, "get_open_position_pairs", lambda e: {f"p{i}" for i in range(11)})
+    monkeypatch.setattr(
+        orch, "get_open_position_pairs", lambda e: {f"p{i}" for i in range(11)}
+    )
     build_called = {}
 
     def fake_build_payload(*a, **k):
@@ -338,6 +343,26 @@ def test_place_sl_tp_cancels_existing():
             None,
             {"stopPrice": 2, "closePosition": True},
         ),
+    ]
+
+
+class ImmediateTriggerExchange(CaptureExchange):
+    def fetch_ticker(self, symbol):
+        return {"last": 100}
+
+
+def test_place_sl_tp_skips_immediate_trigger():
+    ex = ImmediateTriggerExchange()
+    orch._place_sl_tp(ex, "BTC/USDT", "buy", 10, 110, 120)
+    assert ex.orders == [
+        (
+            "BTC/USDT",
+            "TAKE_PROFIT_MARKET",
+            "sell",
+            None,
+            None,
+            {"stopPrice": 120, "closePosition": True},
+        )
     ]
 
 


### PR DESCRIPTION
## Summary
- Check current price before placing stop-loss or take-profit orders and skip invalid levels
- Add unit test ensuring immediate-trigger orders are ignored

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b9480387bc832383fec956ffa2edbc