### PR TITLE
Support forex via OANDA with DXY and session filters

### DIFF
--- a/.env
+++ b/.env
@@ -1,6 +1,6 @@
-OANDA_API_KEY=your_oanda_api_key
-OANDA_ACCOUNT_ID=your_oanda_account_id
-OANDA_API_URL=https://api-fxpractice.oanda.com/v3
+FXCM_API_KEY=your_fxcm_api_key
+FXCM_ACCOUNT_ID=your_fxcm_account_id
+FXCM_API_URL=https://api-demo.fxcm.com
 TE_API_KEY=your_trading_economics_key
 OPENAI_API_KEY=your_openai_api_key
 NANO_MODEL=gpt-5-nano

--- a/.env
+++ b/.env
@@ -1,8 +1,9 @@
-BINANCE_API_KEY=your_binance_api_key
-BINANCE_SECRET=your_binance_secret
+OANDA_API_KEY=your_oanda_api_key
+OANDA_ACCOUNT_ID=your_oanda_account_id
+TE_API_KEY=your_trading_economics_key
 OPENAI_API_KEY=your_openai_api_key
 NANO_MODEL=gpt-5-nano
 MINI_MODEL=gpt-5-mini
 LIVE=false
-LIMIT=20
+FOREX_PAIRS=XAUUSD
 DEFAULT_RISK=0.005

--- a/.env.demo
+++ b/.env.demo
@@ -1,7 +1,7 @@
-# Example configuration for an OANDA practice account
-OANDA_API_KEY=your_demo_api_key
-OANDA_ACCOUNT_ID=your_demo_account_id
-OANDA_API_URL=https://api-fxpractice.oanda.com/v3
+# Example configuration for an FXCM practice account
+FXCM_API_KEY=your_demo_api_key
+FXCM_ACCOUNT_ID=your_demo_account_id
+FXCM_API_URL=https://api-demo.fxcm.com
 TE_API_KEY=your_trading_economics_key
 OPENAI_API_KEY=your_openai_api_key
 NANO_MODEL=gpt-5-nano

--- a/.env.demo
+++ b/.env.demo
@@ -1,5 +1,6 @@
-OANDA_API_KEY=your_oanda_api_key
-OANDA_ACCOUNT_ID=your_oanda_account_id
+# Example configuration for an OANDA practice account
+OANDA_API_KEY=your_demo_api_key
+OANDA_ACCOUNT_ID=your_demo_account_id
 OANDA_API_URL=https://api-fxpractice.oanda.com/v3
 TE_API_KEY=your_trading_economics_key
 OPENAI_API_KEY=your_openai_api_key

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 __pycache__/
 .venv/
+bot.log

--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 Automated trading bot orchestrator for 1h timeframe with 4h/1d context, including scheduled checks and order management.
 
+The bot now targets the **forex** market using the OANDA API and is
+optimised for trading **XAU/USD**.  The payload includes the US Dollar
+Index (DXY) and a session filter only allows trades between the London and
+New York sessions (06:00–16:00 UTC).
+
 This build automatically removes JSON metadata for cancelled or unmapped limit orders without open positions before calling the GPT API.
 
 The stop-loss manager shifts the stop-loss to the entry price once the first take-profit is hit.

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ Automated trading bot orchestrator for 1h timeframe with 4h/1d context, includin
 
 The bot now targets the **forex** market using the OANDA API and is
 optimised for trading **XAU/USD**.  The payload includes the US Dollar
-Index (DXY) and a session filter only allows trades between the London and
-New York sessions (06:00–16:00 UTC).
+Index (DXY), latest forex news, and a session filter only allows trades
+between the London and New York sessions (06:00–16:00 UTC).
 
 This build automatically removes JSON metadata for cancelled or unmapped limit orders without open positions before calling the GPT API.
 
@@ -28,4 +28,5 @@ TE_API_KEY=your_api_key_here
 ```
 
 If the key is missing or the request fails, the bot will continue
-operating but the `events` section of the payload will be empty.
+operating but the `events` and `news` sections of the payload will be
+empty.

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 Automated trading bot orchestrator for 1h timeframe with 4h/1d context, including scheduled checks and order management.
 
-The bot now targets the **forex** market using the OANDA API and is
-optimised for trading **XAU/USD**.  The payload includes the US Dollar
+The bot now targets the **forex** market using the FXCM API and is
+optimised for trading **XAU/USD**. The payload includes the US Dollar
 Index (DXY), latest forex news, and a session filter only allows trades
 between the London and New York sessions (06:00–16:00 UTC).
 
@@ -14,13 +14,13 @@ The stop-loss manager shifts the stop-loss to the entry price once the first tak
 ## Configuration
 
 Create a `.env` file with your credentials and desired pairs. **Both**
-`OANDA_API_KEY` and `OANDA_ACCOUNT_ID` must be set or the application will
+`FXCM_API_KEY` and `FXCM_ACCOUNT_ID` must be set or the application will
 refuse to start. The following variables are recognised:
 
 ```env
-OANDA_API_KEY=your_oanda_api_key
-OANDA_ACCOUNT_ID=your_oanda_account_id
-OANDA_API_URL=https://api-fxpractice.oanda.com/v3
+FXCM_API_KEY=your_fxcm_api_key
+FXCM_ACCOUNT_ID=your_fxcm_account_id
+FXCM_API_URL=https://api-demo.fxcm.com
 TE_API_KEY=your_trading_economics_key
 OPENAI_API_KEY=your_openai_api_key
 
@@ -28,14 +28,14 @@ OPENAI_API_KEY=your_openai_api_key
 FOREX_PAIRS=XAUUSD
 ```
 
-### OANDA practice accounts
+### FXCM practice accounts
 
-OANDA provides free **practice** accounts for testing and backtesting. A
-practice API key and account ID are distinct from live credentials and use
-the base URL `https://api-fxpractice.oanda.com`. You can choose a virtual
-balance of 10k, 50k or 100k USD; prices mirror the real market but orders do
-not risk real funds. To trade live, replace `OANDA_API_URL` with
-`https://api-fxtrade.oanda.com/v3` and supply your live credentials.
+FXCM provides free **demo** accounts for testing and backtesting. A demo
+API token and account ID are distinct from live credentials and use the
+base URL `https://api-demo.fxcm.com`. You can choose a virtual balance and
+trade with real-time prices without risking funds. To trade live, replace
+`FXCM_API_URL` with `https://api.fxcm.com` and supply your live
+credentials.
 
 ### Economic events API
 

--- a/README.md
+++ b/README.md
@@ -13,8 +13,9 @@ The stop-loss manager shifts the stop-loss to the entry price once the first tak
 
 ## Configuration
 
-Create a `.env` file with your credentials and desired pairs. At minimum
-the following variables are recognised:
+Create a `.env` file with your credentials and desired pairs. **Both**
+`OANDA_API_KEY` and `OANDA_ACCOUNT_ID` must be set or the application will
+refuse to start. The following variables are recognised:
 
 ```env
 OANDA_API_KEY=your_oanda_api_key

--- a/README.md
+++ b/README.md
@@ -20,12 +20,22 @@ refuse to start. The following variables are recognised:
 ```env
 OANDA_API_KEY=your_oanda_api_key
 OANDA_ACCOUNT_ID=your_oanda_account_id
+OANDA_API_URL=https://api-fxpractice.oanda.com/v3
 TE_API_KEY=your_trading_economics_key
 OPENAI_API_KEY=your_openai_api_key
 
 # Comma separated list of forex pairs (e.g. XAUUSD,EURUSD)
 FOREX_PAIRS=XAUUSD
 ```
+
+### OANDA practice accounts
+
+OANDA provides free **practice** accounts for testing and backtesting. A
+practice API key and account ID are distinct from live credentials and use
+the base URL `https://api-fxpractice.oanda.com`. You can choose a virtual
+balance of 10k, 50k or 100k USD; prices mirror the real market but orders do
+not risk real funds. To trade live, replace `OANDA_API_URL` with
+`https://api-fxtrade.oanda.com/v3` and supply your live credentials.
 
 ### Economic events API
 

--- a/README.md
+++ b/README.md
@@ -13,20 +13,24 @@ The stop-loss manager shifts the stop-loss to the entry price once the first tak
 
 ## Configuration
 
-Specify the trading pairs to analyse via the `COIN_PAIRS` variable in your `.env` file. Use a comma-separated list of pairs (e.g. `COIN_PAIRS=BTCUSDT,ETHUSDT`).
+Create a `.env` file with your credentials and desired pairs. At minimum
+the following variables are recognised:
+
+```env
+OANDA_API_KEY=your_oanda_api_key
+OANDA_ACCOUNT_ID=your_oanda_account_id
+TE_API_KEY=your_trading_economics_key
+OPENAI_API_KEY=your_openai_api_key
+
+# Comma separated list of forex pairs (e.g. XAUUSD,EURUSD)
+FOREX_PAIRS=XAUUSD
+```
 
 ### Economic events API
 
-Upcoming macroeconomic events are fetched from the
-[Trading Economics](https://tradingeconomics.com/api/) calendar API. Set
-the `TE_API_KEY` environment variable with your API token to enable
-event retrieval. If the variable is not set, the public `guest:guest`
-key is used (subject to rate limits):
-
-```env
-TE_API_KEY=your_api_key_here
-```
-
-If the key is missing or the request fails, the bot will continue
-operating but the `events` and `news` sections of the payload will be
-empty.
+Upcoming macroeconomic events and news are fetched from the
+[Trading Economics](https://tradingeconomics.com/api/) API. If
+`TE_API_KEY` is not set, the public `guest:guest` key is used (subject to
+rate limits). When the key is missing or the request fails, the bot
+continues operating but the `events` and `news` sections of the payload
+will be empty.

--- a/backtest.py
+++ b/backtest.py
@@ -1,6 +1,6 @@
 """Simple RSI-based backtesting pipeline.
 
-This script downloads historical candles from Binance futures via CCXT,
+This script downloads historical candles from the OANDA forex exchange via CCXT,
 computes technical indicators and runs a toy RSI strategy to demonstrate how
 one might wire the existing helpers into a backtest.
 """

--- a/backtest.py
+++ b/backtest.py
@@ -64,7 +64,9 @@ def run_backtest(symbol: str, timeframe: str, limit: int, since: int | None) -> 
 
 def _parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Run a simple backtest")
-    parser.add_argument("--symbol", default="BTC/USDT", help="CCXT symbol, e.g. BTC/USDT")
+    parser.add_argument(
+        "--symbol", default="XAU/USD", help="CCXT symbol, e.g. XAU/USD"
+    )
     parser.add_argument("--timeframe", default="1h", help="Candle timeframe")
     parser.add_argument("--limit", type=int, default=500, help="Number of candles to fetch")
     parser.add_argument(

--- a/backtest.py
+++ b/backtest.py
@@ -1,6 +1,6 @@
 """Simple RSI-based backtesting pipeline.
 
-This script downloads historical candles from the OANDA forex exchange via CCXT,
+This script downloads historical candles from the FXCM forex exchange via CCXT,
 computes technical indicators and runs a toy RSI strategy to demonstrate how
 one might wire the existing helpers into a backtest.
 """

--- a/bot_deployment_steps.txt
+++ b/bot_deployment_steps.txt
@@ -34,8 +34,8 @@ scp -i /home/duongminhlong/Downloads/bot-trading.pem "/home/duongminhlong/Finall
 
 scp -i /home/duongminhlong/Downloads/bot-trading.pem "/home/duongminhlong/Finally_trading/function_helper/function_helper.py" ubuntu@47.130.82.78:~/Finally_trading/function_helper
 
-scp -i /home/duongminhlong/Downloads/bot-trading.pem "/home/duongminhlong/Finally_trading/logs/WIFUSDT.json" ubuntu@47.130.82.78:~/Finally_trading/active_orders
-scp -i /home/duongminhlong/Downloads/bot-trading.pem "/home/duongminhlong/Finally_trading/logs/ZKUSDT.json" ubuntu@47.130.82.78:~/Finally_trading/active_orders
+scp -i /home/duongminhlong/Downloads/bot-trading.pem "/home/duongminhlong/Finally_trading/logs/XAUUSD.json" ubuntu@47.130.82.78:~/Finally_trading/active_orders
+scp -i /home/duongminhlong/Downloads/bot-trading.pem "/home/duongminhlong/Finally_trading/logs/EURUSD.json" ubuntu@47.130.82.78:~/Finally_trading/active_orders
 
 
 scp -i /home/duongminhlong/Downloads/bot-trading.pem "/home/duongminhlong/Finally_trading/function_helper/function_helper.py" ubuntu@47.130.82.78:~/Finally_trading
@@ -95,8 +95,8 @@ screen -ls
 screen -r bot      # quay lại bot
 
 Downfile log 
-scp -i /home/duongminhlong/Downloads/bot-trading.pem  ubuntu@47.130.82.78:~/Finally_trading/active_orders/WIFUSDT.json "/home/duongminhlong/Finally_trading/logs"
-scp -i /home/duongminhlong/Downloads/bot-trading.pem  ubuntu@47.130.82.78:~/Finally_trading/active_orders/ZKUSDT.json "/home/duongminhlong/Finally_trading/logs"
+scp -i /home/duongminhlong/Downloads/bot-trading.pem  ubuntu@47.130.82.78:~/Finally_trading/active_orders/XAUUSD.json "/home/duongminhlong/Finally_trading/logs"
+scp -i /home/duongminhlong/Downloads/bot-trading.pem  ubuntu@47.130.82.78:~/Finally_trading/active_orders/EURUSD.json "/home/duongminhlong/Finally_trading/logs"
 scp -i /home/duongminhlong/Downloads/bot-trading.pem  ubuntu@47.130.82.78:~/Finally_trading/logs/*.log "/home/duongminhlong/Finally_trading/logs"
 
 scp  -i /home/duongminhlong/Downloads/bot-trading.pem  ubuntu@47.130.82.78:~/bot*.log "/home/duongminhlong/scaping_trading/"

--- a/exchange_utils.py
+++ b/exchange_utils.py
@@ -194,6 +194,7 @@ def make_exchange() -> Any:
     logger.info("Initializing OANDA exchange client")
     api_key = os.getenv("OANDA_API_KEY")
     account_id = os.getenv("OANDA_ACCOUNT_ID")
+    api_url = os.getenv("OANDA_API_URL")
     if not api_key or "your_oanda_api_key" in api_key.lower():
         raise RuntimeError("OANDA_API_KEY is required; set it in your environment or .env file")
     if not account_id or "your_oanda_account_id" in account_id.lower():
@@ -203,6 +204,8 @@ def make_exchange() -> Any:
     oanda_cls = getattr(ccxt, "oanda", None)
     if oanda_cls is not None:
         exchange = oanda_cls({"enableRateLimit": True})
+        if api_url:
+            exchange.urls["api"] = api_url
         exchange.apiKey = api_key
         exchange.uid = account_id
         return exchange

--- a/exchange_utils.py
+++ b/exchange_utils.py
@@ -194,13 +194,17 @@ def make_exchange() -> Any:
     logger.info("Initializing OANDA exchange client")
     api_key = os.getenv("OANDA_API_KEY")
     account_id = os.getenv("OANDA_ACCOUNT_ID")
+    if not api_key or "your_oanda_api_key" in api_key.lower():
+        raise RuntimeError("OANDA_API_KEY is required; set it in your environment or .env file")
+    if not account_id or "your_oanda_account_id" in account_id.lower():
+        raise RuntimeError(
+            "OANDA_ACCOUNT_ID is required; set it in your environment or .env file"
+        )
     oanda_cls = getattr(ccxt, "oanda", None)
     if oanda_cls is not None:
         exchange = oanda_cls({"enableRateLimit": True})
-        if api_key:
-            exchange.apiKey = api_key
-        if account_id:
-            exchange.uid = account_id
+        exchange.apiKey = api_key
+        exchange.uid = account_id
         return exchange
 
     logger.warning("ccxt installation missing OANDA; using REST fallback")

--- a/exchange_utils.py
+++ b/exchange_utils.py
@@ -4,39 +4,207 @@ from __future__ import annotations
 
 import logging
 import os
-from typing import Dict
+from typing import Any, Dict
 
 import ccxt
 import pandas as pd
+import requests
+from datetime import datetime
 
 from env_utils import rfloat
 
 logger = logging.getLogger(__name__)
 
 
-def make_exchange() -> ccxt.Exchange:
+class OandaREST:
+    """Lightweight OANDA client used when ccxt lacks native support."""
+
+    def __init__(self, api_key: str | None = None, account_id: str | None = None):
+        self.apiKey = api_key
+        self.uid = account_id
+        self.session = requests.Session()
+        self.base_url = os.getenv(
+            "OANDA_API_URL", "https://api-fxpractice.oanda.com/v3"
+        )
+        self.session.headers.update({"Content-Type": "application/json"})
+        if api_key:
+            self.session.headers["Authorization"] = f"Bearer {api_key}"
+        # minimal markets info for symbol resolution and qty_step
+        self.markets = {
+            "XAU/USD": {
+                "id": "XAU_USD",
+                "symbol": "XAU/USD",
+                "base": "XAU",
+                "quote": "USD",
+                "precision": {"amount": 0.01, "price": 0.01},
+                "limits": {"amount": {"min": 0.01, "step": 0.01}},
+            }
+        }
+        self.options: Dict[str, Any] = {}
+
+    # ---- helpers -----------------------------------------------------
+    def _instrument(self, symbol: str) -> str:
+        return symbol.replace("/", "_")
+
+    # ---- public ccxt-style methods ----------------------------------
+    def fetch_ohlcv(
+        self, symbol: str, timeframe: str, since: int | None = None, limit: int = 100
+    ):
+        tf_map = {
+            "1m": "M1",
+            "5m": "M5",
+            "15m": "M15",
+            "30m": "M30",
+            "1h": "H1",
+            "4h": "H4",
+            "1d": "D",
+        }
+        params = {"granularity": tf_map.get(timeframe, "M1"), "count": limit}
+        if since is not None:
+            iso = datetime.utcfromtimestamp(since / 1000).isoformat("T") + "Z"
+            params["from"] = iso
+        url = f"{self.base_url}/instruments/{self._instrument(symbol)}/candles"
+        r = self.session.get(url, params=params)
+        r.raise_for_status()
+        candles = r.json().get("candles", [])
+        out = []
+        for c in candles:
+            ts = int(datetime.fromisoformat(c["time"].replace("Z", "+00:00")).timestamp() * 1000)
+            mid = c.get("mid") or {}
+            out.append(
+                [
+                    ts,
+                    float(mid.get("o", 0)),
+                    float(mid.get("h", 0)),
+                    float(mid.get("l", 0)),
+                    float(mid.get("c", 0)),
+                    float(c.get("volume", 0)),
+                ]
+            )
+        return out
+
+    def fetch_order_book(self, symbol: str, limit: int = 10):
+        url = f"{self.base_url}/instruments/{self._instrument(symbol)}/orderBook"
+        r = self.session.get(url)
+        r.raise_for_status()
+        data = r.json()
+        buckets = data.get("buckets", [])
+        # Use long/short percentage as proxy volumes
+        bids = []
+        asks = []
+        for b in buckets[:limit]:
+            price = float(b.get("price"))
+            bids.append([price, float(b.get("longCountPercent", 0))])
+            asks.append([price, float(b.get("shortCountPercent", 0))])
+        return {"bids": bids, "asks": asks}
+
+    def fetch_open_orders(self, symbol: str | None = None):
+        url = f"{self.base_url}/accounts/{self.uid}/orders"
+        params = {"state": "PENDING"}
+        if symbol:
+            params["instrument"] = self._instrument(symbol)
+        r = self.session.get(url, params=params)
+        r.raise_for_status()
+        orders = r.json().get("orders", [])
+        return [{"id": o.get("id"), "symbol": symbol} for o in orders]
+
+    def cancel_order(self, order_id: str, symbol: str | None = None):
+        url = f"{self.base_url}/accounts/{self.uid}/orders/{order_id}/cancel"
+        r = self.session.put(url)
+        r.raise_for_status()
+        return r.json()
+
+    def create_order(
+        self,
+        symbol: str,
+        typ: str,
+        side: str,
+        qty: float,
+        price: float | None,
+        params: Dict | None = None,
+    ):
+        url = f"{self.base_url}/accounts/{self.uid}/orders"
+        data: Dict[str, Any] = {
+            "order": {
+                "instrument": self._instrument(symbol),
+                "units": str(qty if side.lower() == "buy" else -qty),
+                "type": "MARKET" if typ.lower() == "market" else "LIMIT",
+                "timeInForce": "FOK" if typ.lower() == "market" else "GTC",
+            }
+        }
+        if price is not None:
+            data["order"]["price"] = str(price)
+        if params:
+            data["order"].update(params)
+        r = self.session.post(url, json=data)
+        r.raise_for_status()
+        return r.json().get("orderCreateTransaction", {"id": None})
+
+    def fetch_order(self, order_id: str, symbol: str | None = None):
+        url = f"{self.base_url}/accounts/{self.uid}/orders/{order_id}"
+        r = self.session.get(url)
+        r.raise_for_status()
+        return r.json().get("order", {})
+
+    def fetch_positions(self):
+        url = f"{self.base_url}/accounts/{self.uid}/positions"
+        r = self.session.get(url)
+        r.raise_for_status()
+        positions = []
+        for p in r.json().get("positions", []):
+            inst = p.get("instrument", "")
+            sym = inst.replace("_", "/")
+            long_units = float(p.get("long", {}).get("units", 0))
+            short_units = float(p.get("short", {}).get("units", 0))
+            net = long_units + short_units
+            entry = float(p.get("long", {}).get("averagePrice") or p.get("short", {}).get("averagePrice") or 0)
+            positions.append({"symbol": sym, "contracts": net, "entryPrice": entry})
+        return positions
+
+    def fetch_balance(self):
+        url = f"{self.base_url}/accounts/{self.uid}/summary"
+        r = self.session.get(url)
+        r.raise_for_status()
+        bal = float(r.json().get("account", {}).get("balance", 0))
+        return {"total": {"USD": bal}}
+
+    def fetch_ticker(self, symbol: str):
+        url = f"{self.base_url}/accounts/{self.uid}/pricing"
+        params = {"instruments": self._instrument(symbol)}
+        r = self.session.get(url, params=params)
+        r.raise_for_status()
+        prices = r.json().get("prices", [{}])[0]
+        bid = float(prices.get("bids", [{}])[0].get("price", 0))
+        ask = float(prices.get("asks", [{}])[0].get("price", 0))
+        last = (bid + ask) / 2 if bid and ask else 0
+        return {"bid": bid, "ask": ask, "last": last}
+
+    def market(self, symbol: str):
+        return self.markets.get(symbol, {})
+
+
+def make_exchange() -> Any:
     """Create an OANDA client using API keys from the environment.
 
-    Some minimal environments may ship a stripped-down build of
-    :mod:`ccxt` that lacks the ``oanda`` exchange class.  Instead of
-    throwing a bare ``AttributeError`` when this occurs, raise a more
-    descriptive ``RuntimeError`` so callers know how to resolve the
-    issue (typically by installing a full ``ccxt`` distribution).
+    Uses ``ccxt.oanda`` when available; otherwise falls back to a minimal
+    REST implementation so the rest of the application can run in
+    environments where ccxt ships without OANDA support.
     """
 
     logger.info("Initializing OANDA exchange client")
-    oanda_cls = getattr(ccxt, "oanda", None)
-    if oanda_cls is None:
-        raise RuntimeError("ccxt installation missing OANDA support; upgrade ccxt")
-
-    exchange = oanda_cls({"enableRateLimit": True})
     api_key = os.getenv("OANDA_API_KEY")
     account_id = os.getenv("OANDA_ACCOUNT_ID")
-    if api_key:
-        exchange.apiKey = api_key
-    if account_id:
-        exchange.uid = account_id
-    return exchange
+    oanda_cls = getattr(ccxt, "oanda", None)
+    if oanda_cls is not None:
+        exchange = oanda_cls({"enableRateLimit": True})
+        if api_key:
+            exchange.apiKey = api_key
+        if account_id:
+            exchange.uid = account_id
+        return exchange
+
+    logger.warning("ccxt installation missing OANDA; using REST fallback")
+    return OandaREST(api_key=api_key, account_id=account_id)
 
 
 def fetch_ohlcv_df(

--- a/exchange_utils.py
+++ b/exchange_utils.py
@@ -1,223 +1,30 @@
-"""Helpers for interacting with the Binance futures exchange."""
+"""Helpers for interacting with the OANDA forex exchange."""
 
 from __future__ import annotations
 
-import json
-import os
-import time
-from typing import Dict, List
 import logging
+import os
+from typing import Dict
 
 import ccxt
 import pandas as pd
-import requests
 
 from env_utils import rfloat
 
-
 logger = logging.getLogger(__name__)
-
-# Stablecoins that should not be traded
-STABLE_BASES = {
-    "USDT",
-    "USDC",
-    "BUSD",
-    "TUSD",
-    "FDUSD",
-    "USDP",
-    "SUSD",
-    "USTC",
-    "DAI",
-}
-
-# Symbols to skip when building the market universe
-BLACKLIST_BASES = {"BTC", "BNB"} | STABLE_BASES
-
-
-# Cache for CoinGecko market cap results
-_MCAP_CACHE: Dict[str, object] = {"timestamp": 0.0, "data": []}
 
 
 def make_exchange() -> ccxt.Exchange:
-    """Create a Binance futures client using API keys from the environment."""
-    logger.info("Initializing Binance futures exchange client")
-    exchange = ccxt.binance(
-        {"enableRateLimit": True, "options": {"defaultType": "future"}}
-    )
-    api_key, secret = os.getenv("BINANCE_API_KEY"), os.getenv("BINANCE_SECRET")
-    if api_key and secret:
-        exchange.apiKey, exchange.secret = api_key, secret
+    """Create an OANDA client using API keys from the environment."""
+    logger.info("Initializing OANDA exchange client")
+    exchange = ccxt.oanda({"enableRateLimit": True})
+    api_key = os.getenv("OANDA_API_KEY")
+    account_id = os.getenv("OANDA_ACCOUNT_ID")
+    if api_key:
+        exchange.apiKey = api_key
+    if account_id:
+        exchange.uid = account_id
     return exchange
-
-
-def load_usdtm(exchange: ccxt.Exchange) -> Dict[str, Dict]:
-    """Return all active USDT-margined futures markets excluding stablecoins and other blacklisted bases."""
-
-    markets = exchange.load_markets()
-    out: Dict[str, Dict] = {}
-    for m in markets.values():
-        if (
-            m.get("linear")
-            and m.get("swap")
-            and m.get("quote") == "USDT"
-            and m.get("active")
-        ):
-            base = m.get("base", "")
-            if base not in BLACKLIST_BASES:
-                out[m["symbol"]] = m
-    logger.info("Loaded %d USDT-margined markets", len(out))
-    return out
-
-
-def top_by_qv(exchange: ccxt.Exchange, limit: int = 20) -> List[str]:
-    """Return ``limit`` symbols sorted by quote volume."""
-
-    markets = load_usdtm(exchange)
-    symbols = list(markets.keys())
-    try:
-        tickers = exchange.fetch_tickers()
-        scored = []
-        for sym in symbols:
-            qv = (tickers.get(sym) or {}).get("quoteVolume") or 0
-            scored.append((sym, float(qv)))
-        scored.sort(key=lambda x: x[1], reverse=True)
-        return [s for s, _ in scored[:limit]]
-    except Exception as e:
-        logger.warning("top_by_qv error: %s", e)
-        return symbols[:limit]
-
-
-def cache_top_by_qv(
-    exchange: ccxt.Exchange,
-    limit: int = 100,
-    *,
-    ttl: float = 3600,
-    path: str = "cache/top_volume.json",
-    min_qv: float = 0.0,
-) -> List[str]:
-    """Return top symbols by quote volume using a JSON cache.
-
-    The cache stores a list of objects containing the original ``symbol`` and a
-    normalised ``base`` (numeric prefixes removed) so that tokens like
-    ``1000PEPE`` are not duplicated when refreshed.
-    """
-
-    try:
-        if os.path.exists(path) and time.time() - os.path.getmtime(path) < ttl:
-            with open(path, "r", encoding="utf-8") as fh:
-                data = json.load(fh) or []
-            return [item.get("symbol") for item in data][:limit]
-    except Exception as e:  # pragma: no cover - IO failures
-        logger.warning("cache_top_by_qv read error: %s", e)
-
-    markets = load_usdtm(exchange)
-    try:
-        tickers = exchange.fetch_tickers()
-    except Exception as e:  # pragma: no cover - network failures
-        logger.warning("cache_top_by_qv fetch error: %s", e)
-        return list(markets.keys())[:limit]
-
-    try:
-        from payload_builder import strip_numeric_prefix
-    except Exception:  # pragma: no cover - circular import
-        def strip_numeric_prefix(s: str) -> str:
-            return s
-
-    scored: Dict[str, Dict] = {}
-    for sym, m in markets.items():
-        qv = float((tickers.get(sym) or {}).get("quoteVolume") or 0)
-        if qv < min_qv:
-            continue
-        base = m.get("base") or ""
-        norm = strip_numeric_prefix(base)
-        info = scored.get(norm)
-        if not info or qv > info["qv"]:
-            scored[norm] = {"symbol": sym, "qv": qv, "base": norm}
-
-    top = sorted(scored.values(), key=lambda x: x["qv"], reverse=True)[:limit]
-
-    os.makedirs(os.path.dirname(path), exist_ok=True)
-    try:
-        with open(path, "w", encoding="utf-8") as fh:
-            json.dump(top, fh)
-    except Exception as e:  # pragma: no cover - IO failures
-        logger.warning("cache_top_by_qv write error: %s", e)
-
-    return [item["symbol"] for item in top]
-
-
-def top_gainers(exchange: ccxt.Exchange, limit: int = 20) -> List[str]:
-    """Return symbols sorted by 24h percentage change."""
-
-    markets = load_usdtm(exchange)
-    try:
-        tickers = exchange.fetch_tickers()
-    except Exception as e:  # pragma: no cover - network failures
-        logger.warning("top_gainers error: %s", e)
-        return []
-
-    try:
-        from payload_builder import strip_numeric_prefix
-    except Exception:  # pragma: no cover - circular import
-        def strip_numeric_prefix(s: str) -> str:
-            return s
-
-    scored = []
-    for sym, m in markets.items():
-        pct = (tickers.get(sym) or {}).get("percentage")
-        if pct is None:
-            pct = (tickers.get(sym) or {}).get("info", {}).get("priceChangePercent")
-        try:
-            pct_val = float(pct)
-        except Exception:
-            continue
-        base = strip_numeric_prefix(m.get("base") or "")
-        if base in BLACKLIST_BASES:
-            continue
-        scored.append((sym, pct_val))
-
-    scored.sort(key=lambda x: x[1], reverse=True)
-    return [s for s, _ in scored[:limit]]
-
-
-def top_by_market_cap(limit: int = 30, *, ttl: float = 3600) -> List[str]:
-    """Return top coin symbols sorted by market cap using the CoinGecko API.
-
-    Results are cached in-memory for ``ttl`` seconds to avoid hitting the
-    CoinGecko API on every call.
-    """
-
-    now = time.time()
-    cached = _MCAP_CACHE["data"]
-    if cached and now - _MCAP_CACHE["timestamp"] < ttl and len(cached) >= limit:
-        return cached[:limit]
-
-    per_page = min(250, max(limit * 2, limit + len(BLACKLIST_BASES)))
-    try:
-        resp = requests.get(
-            "https://api.coingecko.com/api/v3/coins/markets",
-            params={
-                "vs_currency": "usd",
-                "order": "market_cap_desc",
-                "per_page": per_page,
-                "page": 1,
-                "sparkline": "false",
-            },
-            timeout=10,
-        )
-        resp.raise_for_status()
-        data = resp.json() or []
-        symbols = [
-            str(item.get("symbol", "")).upper()
-            for item in data
-            if str(item.get("symbol", "")).upper() not in BLACKLIST_BASES
-        ]
-        _MCAP_CACHE["timestamp"] = now
-        _MCAP_CACHE["data"] = symbols
-        return symbols[:limit]
-    except Exception as e:
-        logger.warning("top_by_market_cap error: %s", e)
-        return cached[:limit] if cached else []
 
 
 def fetch_ohlcv_df(
@@ -261,96 +68,3 @@ def orderbook_snapshot(exchange: ccxt.Exchange, symbol: str, depth: int = 10) ->
     except Exception as e:
         logger.warning("orderbook_snapshot error for %s: %s", symbol, e)
         return {}
-
-
-def funding_snapshot(exchange: ccxt.Exchange, symbol: str) -> Dict:
-    """Return the current funding rate and prediction for ``symbol``."""
-
-    try:
-        fr = exchange.fetch_funding_rate(symbol)
-        info = fr.get("info") or {}
-        rate = fr.get("fundingRate")
-        predicted = info.get("predictedFundingRate")
-        next_ts = fr.get("nextFundingTime") or info.get("nextFundingTime")
-        return {
-            "rate": rfloat(rate, 6),
-            "predicted_rate": rfloat(predicted, 6),
-            "next_ts": int(next_ts) if next_ts else None,
-        }
-    except Exception as e:
-        logger.warning("funding_snapshot error for %s: %s", symbol, e)
-        return {}
-
-
-def open_interest_snapshot(exchange: ccxt.Exchange, symbol: str) -> Dict:
-    """Return the latest open interest for ``symbol``."""
-
-    try:
-        oi = exchange.fetch_open_interest(symbol)
-        amount = (
-            oi.get("openInterestAmount")
-            or oi.get("amount")
-            or oi.get("openInterest")
-        )
-        value = oi.get("openInterestValue") or oi.get("value")
-        out: Dict[str, float] = {}
-        if amount is not None:
-            out["amount"] = rfloat(amount, 6)
-        if value is not None:
-            out["value"] = rfloat(value, 6)
-        return out
-    except Exception as e:
-        logger.warning("open_interest_snapshot error for %s: %s", symbol, e)
-        return {}
-
-
-def cvd_snapshot(exchange: ccxt.Exchange, symbol: str, limit: int = 500) -> Dict:
-    """Return a simple cumulative volume delta over recent trades."""
-
-    try:
-        trades = exchange.fetch_trades(symbol, limit=limit)
-        cvd = 0.0
-        for t in trades:
-            side = t.get("side")
-            amt = float(t.get("amount") or 0)
-            if side == "buy":
-                cvd += amt
-            elif side == "sell":
-                cvd -= amt
-        return {"cvd": rfloat(cvd, 6)}
-    except Exception as e:
-        logger.warning("cvd_snapshot error for %s: %s", symbol, e)
-        return {}
-
-
-def liquidation_snapshot(
-    exchange: ccxt.Exchange, symbol: str, limit: int = 50
-) -> Dict:
-    """Return recent liquidation statistics for ``symbol``."""
-    # ``fetch_liquidations`` is not implemented for all exchanges.  The
-    # Binance client used by this project, for example, does not support it
-    # which resulted in noisy ``NotSupported`` warnings.  Guard against that
-    # here so we simply return an empty payload when the capability is
-    # missing.
-    if not getattr(exchange, "has", {}).get("fetchLiquidations"):
-        return {}
-
-    try:
-        rows = exchange.fetch_liquidations(symbol, limit=limit)
-        long_amt = 0.0
-        short_amt = 0.0
-        for r in rows:
-            amt = float(r.get("amount") or 0)
-            side = r.get("side", "").lower()
-            if side == "long":
-                long_amt += amt
-            elif side == "short":
-                short_amt += amt
-        return {
-            "long_liq": rfloat(long_amt, 6),
-            "short_liq": rfloat(short_amt, 6),
-        }
-    except Exception as e:
-        logger.warning("liquidation_snapshot error for %s: %s", symbol, e)
-        return {}
-

--- a/exchange_utils.py
+++ b/exchange_utils.py
@@ -1,4 +1,4 @@
-"""Helpers for interacting with the OANDA forex exchange."""
+"""Helpers for interacting with the FXCM forex exchange."""
 
 from __future__ import annotations
 
@@ -16,15 +16,15 @@ from env_utils import rfloat
 logger = logging.getLogger(__name__)
 
 
-class OandaREST:
-    """Lightweight OANDA client used when ccxt lacks native support."""
+class FxcmREST:
+    """Lightweight FXCM client used when ccxt lacks native support."""
 
     def __init__(self, api_key: str | None = None, account_id: str | None = None):
         self.apiKey = api_key
         self.uid = account_id
         self.session = requests.Session()
         self.base_url = os.getenv(
-            "OANDA_API_URL", "https://api-fxpractice.oanda.com/v3"
+            "FXCM_API_URL", "https://api-demo.fxcm.com"
         )
         self.session.headers.update({"Content-Type": "application/json"})
         if api_key:
@@ -184,34 +184,34 @@ class OandaREST:
 
 
 def make_exchange() -> Any:
-    """Create an OANDA client using API keys from the environment.
+    """Create an FXCM client using API keys from the environment.
 
-    Uses ``ccxt.oanda`` when available; otherwise falls back to a minimal
+    Uses ``ccxt.fxcm`` when available; otherwise falls back to a minimal
     REST implementation so the rest of the application can run in
-    environments where ccxt ships without OANDA support.
+    environments where ccxt ships without FXCM support.
     """
 
-    logger.info("Initializing OANDA exchange client")
-    api_key = os.getenv("OANDA_API_KEY")
-    account_id = os.getenv("OANDA_ACCOUNT_ID")
-    api_url = os.getenv("OANDA_API_URL")
-    if not api_key or "your_oanda_api_key" in api_key.lower():
-        raise RuntimeError("OANDA_API_KEY is required; set it in your environment or .env file")
-    if not account_id or "your_oanda_account_id" in account_id.lower():
+    logger.info("Initializing FXCM exchange client")
+    api_key = os.getenv("FXCM_API_KEY")
+    account_id = os.getenv("FXCM_ACCOUNT_ID")
+    api_url = os.getenv("FXCM_API_URL")
+    if not api_key or "your_fxcm_api_key" in api_key.lower():
+        raise RuntimeError("FXCM_API_KEY is required; set it in your environment or .env file")
+    if not account_id or "your_fxcm_account_id" in account_id.lower():
         raise RuntimeError(
-            "OANDA_ACCOUNT_ID is required; set it in your environment or .env file"
+            "FXCM_ACCOUNT_ID is required; set it in your environment or .env file"
         )
-    oanda_cls = getattr(ccxt, "oanda", None)
-    if oanda_cls is not None:
-        exchange = oanda_cls({"enableRateLimit": True})
+    fxcm_cls = getattr(ccxt, "fxcm", None)
+    if fxcm_cls is not None:
+        exchange = fxcm_cls({"enableRateLimit": True})
         if api_url:
             exchange.urls["api"] = api_url
         exchange.apiKey = api_key
         exchange.uid = account_id
         return exchange
 
-    logger.warning("ccxt installation missing OANDA; using REST fallback")
-    return OandaREST(api_key=api_key, account_id=account_id)
+    logger.warning("ccxt installation missing FXCM; using REST fallback")
+    return FxcmREST(api_key=api_key, account_id=account_id)
 
 
 def fetch_ohlcv_df(

--- a/futures_gpt_orchestrator_full.py
+++ b/futures_gpt_orchestrator_full.py
@@ -171,7 +171,7 @@ def run(run_live: bool = False, limit: int = 30, ex=None) -> Dict[str, Any]:
     try:
         bal = ex.fetch_balance()
         totals = bal.get("total") or {}
-        capital = float(totals.get("USD") or totals.get("USDT") or 0.0)
+        capital = float(totals.get("USD") or 0.0)
     except Exception as e:
         logger.warning("run fetch_balance error: %s", e)
         capital = 0.0

--- a/futures_gpt_orchestrator_full.py
+++ b/futures_gpt_orchestrator_full.py
@@ -3,7 +3,7 @@
 This script orchestrates the flow:
 1. Build payloads from market data
 2. Generate trading decisions with the MINI model
-3. Optionally place orders on OANDA
+3. Optionally place orders on FXCM
 
 The original monolithic implementation has been refactored into smaller
 modules for clarity and maintainability.

--- a/futures_gpt_orchestrator_full.py
+++ b/futures_gpt_orchestrator_full.py
@@ -204,39 +204,6 @@ def run(run_live: bool = False, limit: int = 30, ex=None) -> Dict[str, Any]:
             "closed": [],
         }
 
-    if run_live:
-        max_pos = env_int("MAX_OPEN_POSITIONS", 10)
-        try:
-            current_pos = len(get_open_position_pairs(ex))
-        except Exception as e:
-            logger.warning("run get_open_position_pairs error: %s", e)
-            current_pos = 0
-        if current_pos >= max_pos:
-            logger.info(
-                "Open positions %s >= max %s, exiting run", current_pos, max_pos
-            )
-            save_text(
-                f"{stamp}_orders.json",
-                dumps_min(
-                    {
-                        "live": run_live,
-                        "capital": capital,
-                        "coins": [],
-                        "placed": [],
-                        "closed": [],
-                        "reason": "max_positions",
-                    }
-                ),
-            )
-            return {
-                "ts": stamp,
-                "live": run_live,
-                "capital": capital,
-                "coins": [],
-                "placed": [],
-                "closed": [],
-            }
-
     payload_full = build_payload(ex, limit)
     save_text(f"{stamp}_payload_full.json", dumps_min(payload_full))
     logger.info("Payload built with %d coins", len(payload_full.get("coins", [])))

--- a/futures_gpt_orchestrator_full.py
+++ b/futures_gpt_orchestrator_full.py
@@ -3,7 +3,7 @@
 This script orchestrates the flow:
 1. Build payloads from market data
 2. Generate trading decisions with the MINI model
-3. Optionally place orders on Binance futures
+3. Optionally place orders on OANDA
 
 The original monolithic implementation has been refactored into smaller
 modules for clarity and maintainability.
@@ -154,7 +154,7 @@ def _place_sl_tp(exchange, symbol, side, qty, sl, tp):
             raise
 
 
-# Default limit increased to 30 to expand the number of coins processed
+# Default limit increased to 30 to expand the number of pairs processed
 def run(run_live: bool = False, limit: int = 30, ex=None) -> Dict[str, Any]:
     """Execute the full payload → decision → order pipeline."""
     start_time = time.time()

--- a/payload_builder.py
+++ b/payload_builder.py
@@ -18,7 +18,7 @@ from exchange_utils import fetch_ohlcv_df, orderbook_snapshot
 import requests
 from indicators import add_indicators, trend_lbl
 from positions import positions_snapshot
-from events import event_snapshot
+from events import event_snapshot, news_snapshot
 
 logger = logging.getLogger(__name__)
 
@@ -218,6 +218,7 @@ def build_payload(
         "type": "forex",
         "time": time_payload(),
         "events": event_snapshot(),
+        "news": news_snapshot(),
         "dxy": dxy_snapshot(),
         "coins": [drop_empty(c) for c in coins],
         "positions": positions,

--- a/prompts.py
+++ b/prompts.py
@@ -2,13 +2,13 @@
 
 from env_utils import dumps_min
 PROMPT_SYS_MINI = (
-    "Bạn là một chuyên gia trading khung 1H (tham chiếu 4H/1D). Dùng đúng 200 nến mỗi khung từ payload để ra quyết định.\n"
+    "Bạn là một chuyên gia trading khung 1H (tham chiếu 4H/1D) cho thị trường forex. Dùng đúng 200 nến mỗi khung từ payload để ra quyết định.\n"
     "DỮ LIỆU ĐẦU VÀO (payload)\n"
-    "- OHLCV 200 nến cho mỗi symbol USDT ở 1H/4H/1D. Dùng tất cả phương pháp có thể như AT, mô hình nến, mô hình sóng .. \n"
+    "- OHLCV 200 nến cho mỗi symbol forex ở 1H/4H/1D. Dùng tất cả phương pháp có thể như AT, mô hình nến, mô hình sóng .. \n"
     "- Vị thế hiện tại: {pair, side, entry, sl, tp, pnl}.\n"
-    "- Tuỳ chọn: derivatives (funding, OI, basis), order flow (CVD/delta, liquidations), volume profile (POC/HVN/LVN), volatility (ATR/HV/IV), on-chain/sentiment, sự kiện. Nếu thiếu, bỏ qua (KHÔNG trừ điểm, KHÔNG suy diễn).\n"
-    "Trả về DUY NHẤT JSON: {\"coins\":[{\"pair\":\"SYMBOLUSDT\",\"entry\":0.00,\"sl\":0.00,\"tp\":0.00,\"conf\":0.0,\"rr\":0}],\"close\":[\"SYMBOLUSDT\"]}.\n"
-    "Yêu cầu : + Tham khảo theo BTC . + CONF ≥ 7.0 và RR ≥ 1.8 . + SL TP theo khung 1h."
+    "- Tuỳ chọn: derivatives (funding, OI, basis), order flow (CVD/delta, liquidations), volume profile (POC/HVN/LVN), volatility (ATR/HV/IV), on-chain/sentiment, sự kiện, tin tức. Nếu thiếu, bỏ qua (KHÔNG trừ điểm, KHÔNG suy diễn).\n"
+    "Trả về DUY NHẤT JSON: {\"coins\":[{\"pair\":\"SYMBOL\",\"entry\":0.00,\"sl\":0.00,\"tp\":0.00,\"conf\":0.0,\"rr\":0}],\"close\":[\"SYMBOL\"]}.\n"
+    "Yêu cầu : + CONF ≥ 7.0 và RR ≥ 1.8 . + SL TP theo khung 1h."
 )
 
 PROMPT_USER_MINI = (

--- a/tests/test_build_payload.py
+++ b/tests/test_build_payload.py
@@ -16,6 +16,7 @@ def test_build_payload_from_env_pairs(monkeypatch):
     monkeypatch.setattr(pb, "coin_payload", lambda ex, sym: {"p": pb.norm_pair_symbol(sym)})
     monkeypatch.setattr(pb, "_tf_with_cache", lambda *a, **k: {"ema": 0})
     monkeypatch.setattr(pb, "event_snapshot", lambda: [])
+    monkeypatch.setattr(pb, "news_snapshot", lambda: [])
 
     payload = pb.build_payload(DummyExchange(), limit=2)
     pairs = {c["p"] for c in payload["coins"]}
@@ -29,6 +30,7 @@ def test_build_payload_handles_numeric_prefix(monkeypatch):
     monkeypatch.setattr(pb, "coin_payload", lambda ex, sym: {"p": pb.norm_pair_symbol(sym)})
     monkeypatch.setattr(pb, "_tf_with_cache", lambda *a, **k: {"ema": 0})
     monkeypatch.setattr(pb, "event_snapshot", lambda: [])
+    monkeypatch.setattr(pb, "news_snapshot", lambda: [])
 
     payload = pb.build_payload(DummyExchange(), limit=1)
     pairs = {c["p"] for c in payload["coins"]}
@@ -42,6 +44,7 @@ def test_build_payload_skips_positions(monkeypatch):
     monkeypatch.setattr(pb, "coin_payload", lambda ex, sym: {"p": pb.norm_pair_symbol(sym)})
     monkeypatch.setattr(pb, "_tf_with_cache", lambda *a, **k: {"ema": 0})
     monkeypatch.setattr(pb, "event_snapshot", lambda: [])
+    monkeypatch.setattr(pb, "news_snapshot", lambda: [])
 
     payload = pb.build_payload(DummyExchange(), limit=2)
     pairs = {c["p"] for c in payload["coins"]}
@@ -61,6 +64,7 @@ def test_build_payload_preserves_sl(monkeypatch):
     monkeypatch.setattr(pb, "coin_payload", lambda ex, sym: {"p": pb.norm_pair_symbol(sym)})
     monkeypatch.setattr(pb, "_tf_with_cache", lambda *a, **k: {"ema": 0})
     monkeypatch.setattr(pb, "event_snapshot", lambda: [])
+    monkeypatch.setattr(pb, "news_snapshot", lambda: [])
 
     payload = pb.build_payload(DummyExchange(), limit=0)
     positions = payload["positions"]
@@ -78,6 +82,22 @@ def test_build_payload_includes_events(monkeypatch):
         {"time": "2024-01-01T00:00:00Z", "title": "CPI", "impact": "high"}
     ]
     monkeypatch.setattr(pb, "event_snapshot", lambda: sample_events)
+    sample_news = [{"time": "2024-01-01T00:00:00Z", "title": "Fed", "url": "http://ex"}]
+    monkeypatch.setattr(pb, "news_snapshot", lambda: sample_news)
 
     payload = pb.build_payload(DummyExchange(), limit=1)
     assert payload["events"] == sample_events
+    assert payload["news"] == sample_news
+
+
+def test_build_payload_includes_news(monkeypatch):
+    monkeypatch.setenv("COIN_PAIRS", "AAA")
+    monkeypatch.setattr(pb, "positions_snapshot", lambda ex: [])
+    monkeypatch.setattr(pb, "coin_payload", lambda ex, sym: {"p": pb.norm_pair_symbol(sym)})
+    monkeypatch.setattr(pb, "_tf_with_cache", lambda *a, **k: {"ema": 0})
+    monkeypatch.setattr(pb, "event_snapshot", lambda: [])
+    sample_news = [{"time": "2024-01-01", "title": "CPI", "url": "http://x"}]
+    monkeypatch.setattr(pb, "news_snapshot", lambda: sample_news)
+
+    payload = pb.build_payload(DummyExchange(), limit=1)
+    assert payload["news"] == sample_news

--- a/tests/test_build_payload.py
+++ b/tests/test_build_payload.py
@@ -11,7 +11,7 @@ class DummyExchange:
 
 
 def test_build_payload_from_env_pairs(monkeypatch):
-    monkeypatch.setenv("COIN_PAIRS", "AAA,BBB")
+    monkeypatch.setenv("FOREX_PAIRS", "XAUUSD,EURUSD")
     monkeypatch.setattr(pb, "positions_snapshot", lambda ex: [])
     monkeypatch.setattr(pb, "coin_payload", lambda ex, sym: {"p": pb.norm_pair_symbol(sym)})
     monkeypatch.setattr(pb, "_tf_with_cache", lambda *a, **k: {"ema": 0})
@@ -20,27 +20,15 @@ def test_build_payload_from_env_pairs(monkeypatch):
 
     payload = pb.build_payload(DummyExchange(), limit=2)
     pairs = {c["p"] for c in payload["coins"]}
-    assert pairs == {"AAAUSDT", "BBBUSDT"}
+    assert pairs == {"XAUUSD", "EURUSD"}
     assert "time" in payload and "eth" not in payload
 
 
-def test_build_payload_handles_numeric_prefix(monkeypatch):
-    monkeypatch.setenv("COIN_PAIRS", "1000PEPE")
-    monkeypatch.setattr(pb, "positions_snapshot", lambda ex: [])
-    monkeypatch.setattr(pb, "coin_payload", lambda ex, sym: {"p": pb.norm_pair_symbol(sym)})
-    monkeypatch.setattr(pb, "_tf_with_cache", lambda *a, **k: {"ema": 0})
-    monkeypatch.setattr(pb, "event_snapshot", lambda: [])
-    monkeypatch.setattr(pb, "news_snapshot", lambda: [])
-
-    payload = pb.build_payload(DummyExchange(), limit=1)
-    pairs = {c["p"] for c in payload["coins"]}
-    assert pairs == {"1000PEPEUSDT"}
-    assert "time" in payload and "eth" not in payload
 
 
 def test_build_payload_skips_positions(monkeypatch):
-    monkeypatch.setenv("COIN_PAIRS", "CCCUSDT,BBBUSDT,AAAUSDT")
-    monkeypatch.setattr(pb, "positions_snapshot", lambda ex: [{"pair": "BBBUSDT"}])
+    monkeypatch.setenv("FOREX_PAIRS", "GBPUSD,EURUSD,XAUUSD")
+    monkeypatch.setattr(pb, "positions_snapshot", lambda ex: [{"pair": "EURUSD"}])
     monkeypatch.setattr(pb, "coin_payload", lambda ex, sym: {"p": pb.norm_pair_symbol(sym)})
     monkeypatch.setattr(pb, "_tf_with_cache", lambda *a, **k: {"ema": 0})
     monkeypatch.setattr(pb, "event_snapshot", lambda: [])
@@ -48,16 +36,16 @@ def test_build_payload_skips_positions(monkeypatch):
 
     payload = pb.build_payload(DummyExchange(), limit=2)
     pairs = {c["p"] for c in payload["coins"]}
-    assert pairs == {"CCCUSDT", "AAAUSDT", "BBBUSDT"}
+    assert pairs == {"GBPUSD", "XAUUSD", "EURUSD"}
 
 
 def test_build_payload_preserves_sl(monkeypatch):
-    monkeypatch.setenv("COIN_PAIRS", "")
+    monkeypatch.setenv("FOREX_PAIRS", "")
 
     def fake_positions_snapshot(ex):
         return [
-            {"pair": "AAAUSDT", "side": "buy", "entry": 1.0, "sl": None},
-            {"pair": "BBBUSDT", "side": "sell", "entry": 2.0, "sl": 1.5},
+            {"pair": "XAUUSD", "side": "buy", "entry": 1.0, "sl": None},
+            {"pair": "EURUSD", "side": "sell", "entry": 2.0, "sl": 1.5},
         ]
 
     monkeypatch.setattr(pb, "positions_snapshot", fake_positions_snapshot)
@@ -73,7 +61,7 @@ def test_build_payload_preserves_sl(monkeypatch):
 
 
 def test_build_payload_includes_events(monkeypatch):
-    monkeypatch.setenv("COIN_PAIRS", "AAA")
+    monkeypatch.setenv("FOREX_PAIRS", "XAUUSD")
     monkeypatch.setattr(pb, "positions_snapshot", lambda ex: [])
     monkeypatch.setattr(pb, "coin_payload", lambda ex, sym: {"p": pb.norm_pair_symbol(sym)})
     monkeypatch.setattr(pb, "_tf_with_cache", lambda *a, **k: {"ema": 0})
@@ -91,7 +79,7 @@ def test_build_payload_includes_events(monkeypatch):
 
 
 def test_build_payload_includes_news(monkeypatch):
-    monkeypatch.setenv("COIN_PAIRS", "AAA")
+    monkeypatch.setenv("FOREX_PAIRS", "XAUUSD")
     monkeypatch.setattr(pb, "positions_snapshot", lambda ex: [])
     monkeypatch.setattr(pb, "coin_payload", lambda ex, sym: {"p": pb.norm_pair_symbol(sym)})
     monkeypatch.setattr(pb, "_tf_with_cache", lambda *a, **k: {"ema": 0})

--- a/tests/test_env_utils.py
+++ b/tests/test_env_utils.py
@@ -2,7 +2,7 @@ from env_utils import save_text
 
 
 def test_save_text_creates_nested_dirs(tmp_path):
-    save_text("limit_orders/HYPEUSDT.json", "hello", folder=str(tmp_path))
-    target = tmp_path / "limit_orders" / "HYPEUSDT.json"
+    save_text("limit_orders/XAUUSD.json", "hello", folder=str(tmp_path))
+    target = tmp_path / "limit_orders" / "XAUUSD.json"
     assert target.exists()
     assert target.read_text() == "hello"

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -23,3 +23,22 @@ def test_event_snapshot_masks_api_key_on_http_error(caplog):
             events.event_snapshot()
     assert "SECRET" not in caplog.text
     assert "c=***" in caplog.text
+
+
+def test_news_snapshot_masks_api_key_on_http_error(caplog):
+    class FakeResp:
+        def raise_for_status(self):
+            request = requests.Request(
+                "GET",
+                "https://api.tradingeconomics.com/news?c=SECRET&f=json",
+            ).prepare()
+            response = requests.Response()
+            response.status_code = 403
+            raise requests.HTTPError("403 Client Error", request=request, response=response)
+
+    with patch("events.requests.get", return_value=FakeResp()):
+        with patch.dict(os.environ, {"TE_API_KEY": "SECRET"}):
+            caplog.set_level(logging.WARNING)
+            events.news_snapshot()
+    assert "SECRET" not in caplog.text
+    assert "c=***" in caplog.text

--- a/tests/test_exchange_utils.py
+++ b/tests/test_exchange_utils.py
@@ -1,173 +1,22 @@
-import pathlib
-import sys
-
-sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
-import exchange_utils  # noqa: E402
-import requests  # noqa: E402
-import json
+import exchange_utils
 
 
-class DummyResponse:
-    def __init__(self, data):
-        self._data = data
-
-    def json(self):
-        return self._data
-
-    def raise_for_status(self):
-        pass
-
-
-def test_load_usdtm_filters_stablecoins():
+def test_fetch_ohlcv_df(monkeypatch):
     class DummyExchange:
-        def load_markets(self):
-            return {
-                "ETH/USDT:USDT": {
-                    "symbol": "ETH/USDT:USDT",
-                    "linear": True,
-                    "swap": True,
-                    "quote": "USDT",
-                    "active": True,
-                    "base": "ETH",
-                },
-                "BUSD/USDT:USDT": {
-                    "symbol": "BUSD/USDT:USDT",
-                    "linear": True,
-                    "swap": True,
-                    "quote": "USDT",
-                    "active": True,
-                    "base": "BUSD",
-                },
-            }
-
-    exchange = DummyExchange()
-    markets = exchange_utils.load_usdtm(exchange)
-    assert "ETH/USDT:USDT" in markets
-    assert "BUSD/USDT:USDT" not in markets
-
-
-def test_top_by_market_cap(monkeypatch):
-    calls = []
-
-    def fake_get(url, params=None, timeout=None):
-        calls.append(1)
-        expected = min(250, max(2 * 2, 2 + len(exchange_utils.BLACKLIST_BASES)))
-        assert params["per_page"] == expected
-        return DummyResponse(
-            [{"symbol": "btc"}, {"symbol": "eth"}, {"symbol": "xrp"}, {"symbol": "usdt"}]
-        )
-
-    monkeypatch.setattr(requests, "get", fake_get)
-    exchange_utils._MCAP_CACHE["timestamp"] = 0
-    exchange_utils._MCAP_CACHE["data"] = []
-    res1 = exchange_utils.top_by_market_cap(2)
-    res2 = exchange_utils.top_by_market_cap(2)
-    assert res1 == ["ETH", "XRP"]
-    assert res2 == ["ETH", "XRP"]
-    assert len(calls) == 1
-
-
-def test_top_by_market_cap_filters_blacklist(monkeypatch):
-    data = [
-        {"symbol": "usdt"},
-        {"symbol": "btc"},
-        {"symbol": "eth"},
-        {"symbol": "bnb"},
-        {"symbol": "xrp"},
-        {"symbol": "ada"},
-    ]
-
-    class Resp:
-        def json(self):
-            return data
-
-        def raise_for_status(self):
-            return None
-
-    monkeypatch.setattr(requests, "get", lambda *a, **k: Resp())
-    exchange_utils._MCAP_CACHE["data"] = []
-    res = exchange_utils.top_by_market_cap(limit=3, ttl=0)
-    assert res == ["ETH", "XRP", "ADA"]
-
-
-def test_liquidation_snapshot_unsupported_exchange(caplog):
-    class DummyExchange:
-        has = {"fetchLiquidations": False}
+        def fetch_ohlcv(self, symbol, timeframe, since=None, limit=None):
+            return [[0, 1, 2, 0, 1, 100]]
 
     ex = DummyExchange()
-    with caplog.at_level("WARNING"):
-        res = exchange_utils.liquidation_snapshot(ex, "ETH/USDT:USDT")
-    assert res == {}
-    assert "liquidation_snapshot error" not in caplog.text
+    df = exchange_utils.fetch_ohlcv_df(ex, "XAU/USD", "1m", limit=1)
+    assert list(df.columns) == ["open", "high", "low", "close", "volume"]
 
 
-def test_cache_top_by_qv_caches_results(monkeypatch, tmp_path):
+def test_orderbook_snapshot_calculates_values():
     class DummyExchange:
-        def load_markets(self):
-            return {
-                "AAA/USDT:USDT": {
-                    "symbol": "AAA/USDT:USDT",
-                    "linear": True,
-                    "swap": True,
-                    "quote": "USDT",
-                    "active": True,
-                    "base": "AAA",
-                }
-            }
+        def fetch_order_book(self, symbol, limit=10):
+            return {"bids": [[10, 1]], "asks": [[11, 1]]}
 
-        def fetch_tickers(self):
-            calls[0] += 1
-            return {"AAA/USDT:USDT": {"quoteVolume": 100}}
-
-    calls = [0]
-    path = tmp_path / "top.json"
-    ex = DummyExchange()
-
-    res1 = exchange_utils.cache_top_by_qv(ex, limit=1, ttl=3600, path=str(path))
-    res2 = exchange_utils.cache_top_by_qv(ex, limit=1, ttl=3600, path=str(path))
-    res3 = exchange_utils.cache_top_by_qv(ex, limit=1, ttl=0, path=str(path))
-
-    assert res1 == ["AAA/USDT:USDT"]
-    assert res2 == ["AAA/USDT:USDT"]
-    assert res3 == ["AAA/USDT:USDT"]
-    assert calls[0] == 2
-
-    with open(path, "r", encoding="utf-8") as fh:
-        data = json.load(fh)
-    assert data[0]["base"] == "AAA"
-
-
-def test_cache_top_by_qv_filters_by_min_qv(tmp_path):
-    class DummyExchange:
-        def load_markets(self):
-            return {
-                "AAA/USDT:USDT": {
-                    "symbol": "AAA/USDT:USDT",
-                    "linear": True,
-                    "swap": True,
-                    "quote": "USDT",
-                    "active": True,
-                    "base": "AAA",
-                },
-                "BBB/USDT:USDT": {
-                    "symbol": "BBB/USDT:USDT",
-                    "linear": True,
-                    "swap": True,
-                    "quote": "USDT",
-                    "active": True,
-                    "base": "BBB",
-                },
-            }
-
-        def fetch_tickers(self):
-            return {
-                "AAA/USDT:USDT": {"quoteVolume": 6_000_000},
-                "BBB/USDT:USDT": {"quoteVolume": 1_000_000},
-            }
-
-    ex = DummyExchange()
-    path = tmp_path / "vol.json"
-    res = exchange_utils.cache_top_by_qv(
-        ex, limit=2, ttl=0, path=str(path), min_qv=5_000_000
-    )
-    assert res == ["AAA/USDT:USDT"]
+    snap = exchange_utils.orderbook_snapshot(DummyExchange(), "XAU/USD")
+    assert snap["sp"] > 0
+    assert snap["b"] > 0
+    assert snap["a"] > 0

--- a/tests/test_exchange_utils.py
+++ b/tests/test_exchange_utils.py
@@ -24,6 +24,15 @@ def test_orderbook_snapshot_calculates_values():
 
 
 def test_make_exchange_falls_back_without_ccxt(monkeypatch):
+    monkeypatch.setenv("OANDA_API_KEY", "k")
+    monkeypatch.setenv("OANDA_ACCOUNT_ID", "a")
     monkeypatch.setattr(exchange_utils.ccxt, "oanda", None, raising=False)
     ex = exchange_utils.make_exchange()
     assert isinstance(ex, exchange_utils.OandaREST)
+
+
+def test_make_exchange_requires_credentials(monkeypatch):
+    monkeypatch.delenv("OANDA_API_KEY", raising=False)
+    monkeypatch.delenv("OANDA_ACCOUNT_ID", raising=False)
+    with pytest.raises(RuntimeError):
+        exchange_utils.make_exchange()

--- a/tests/test_exchange_utils.py
+++ b/tests/test_exchange_utils.py
@@ -1,4 +1,5 @@
 import exchange_utils
+import pytest
 
 
 def test_fetch_ohlcv_df(monkeypatch):
@@ -20,3 +21,9 @@ def test_orderbook_snapshot_calculates_values():
     assert snap["sp"] > 0
     assert snap["b"] > 0
     assert snap["a"] > 0
+
+
+def test_make_exchange_raises_when_oanda_missing(monkeypatch):
+    monkeypatch.setattr(exchange_utils.ccxt, "oanda", None, raising=False)
+    with pytest.raises(RuntimeError):
+        exchange_utils.make_exchange()

--- a/tests/test_exchange_utils.py
+++ b/tests/test_exchange_utils.py
@@ -23,7 +23,7 @@ def test_orderbook_snapshot_calculates_values():
     assert snap["a"] > 0
 
 
-def test_make_exchange_raises_when_oanda_missing(monkeypatch):
+def test_make_exchange_falls_back_without_ccxt(monkeypatch):
     monkeypatch.setattr(exchange_utils.ccxt, "oanda", None, raising=False)
-    with pytest.raises(RuntimeError):
-        exchange_utils.make_exchange()
+    ex = exchange_utils.make_exchange()
+    assert isinstance(ex, exchange_utils.OandaREST)

--- a/tests/test_exchange_utils.py
+++ b/tests/test_exchange_utils.py
@@ -36,3 +36,18 @@ def test_make_exchange_requires_credentials(monkeypatch):
     monkeypatch.delenv("OANDA_ACCOUNT_ID", raising=False)
     with pytest.raises(RuntimeError):
         exchange_utils.make_exchange()
+
+
+def test_make_exchange_uses_api_url_with_ccxt(monkeypatch):
+    class Dummy:
+        def __init__(self, config):
+            self.urls = {"api": "default"}
+            self.apiKey = None
+            self.uid = None
+
+    monkeypatch.setenv("OANDA_API_KEY", "k")
+    monkeypatch.setenv("OANDA_ACCOUNT_ID", "a")
+    monkeypatch.setenv("OANDA_API_URL", "https://example.com/v3")
+    monkeypatch.setattr(exchange_utils.ccxt, "oanda", Dummy, raising=False)
+    ex = exchange_utils.make_exchange()
+    assert ex.urls["api"] == "https://example.com/v3"

--- a/tests/test_exchange_utils.py
+++ b/tests/test_exchange_utils.py
@@ -24,16 +24,16 @@ def test_orderbook_snapshot_calculates_values():
 
 
 def test_make_exchange_falls_back_without_ccxt(monkeypatch):
-    monkeypatch.setenv("OANDA_API_KEY", "k")
-    monkeypatch.setenv("OANDA_ACCOUNT_ID", "a")
-    monkeypatch.setattr(exchange_utils.ccxt, "oanda", None, raising=False)
+    monkeypatch.setenv("FXCM_API_KEY", "k")
+    monkeypatch.setenv("FXCM_ACCOUNT_ID", "a")
+    monkeypatch.setattr(exchange_utils.ccxt, "fxcm", None, raising=False)
     ex = exchange_utils.make_exchange()
-    assert isinstance(ex, exchange_utils.OandaREST)
+    assert isinstance(ex, exchange_utils.FxcmREST)
 
 
 def test_make_exchange_requires_credentials(monkeypatch):
-    monkeypatch.delenv("OANDA_API_KEY", raising=False)
-    monkeypatch.delenv("OANDA_ACCOUNT_ID", raising=False)
+    monkeypatch.delenv("FXCM_API_KEY", raising=False)
+    monkeypatch.delenv("FXCM_ACCOUNT_ID", raising=False)
     with pytest.raises(RuntimeError):
         exchange_utils.make_exchange()
 
@@ -45,9 +45,9 @@ def test_make_exchange_uses_api_url_with_ccxt(monkeypatch):
             self.apiKey = None
             self.uid = None
 
-    monkeypatch.setenv("OANDA_API_KEY", "k")
-    monkeypatch.setenv("OANDA_ACCOUNT_ID", "a")
-    monkeypatch.setenv("OANDA_API_URL", "https://example.com/v3")
-    monkeypatch.setattr(exchange_utils.ccxt, "oanda", Dummy, raising=False)
+    monkeypatch.setenv("FXCM_API_KEY", "k")
+    monkeypatch.setenv("FXCM_ACCOUNT_ID", "a")
+    monkeypatch.setenv("FXCM_API_URL", "https://example.com")
+    monkeypatch.setattr(exchange_utils.ccxt, "fxcm", Dummy, raising=False)
     ex = exchange_utils.make_exchange()
-    assert ex.urls["api"] == "https://example.com/v3"
+    assert ex.urls["api"] == "https://example.com"

--- a/tests/test_futures_gpt_orchestrator_full.py
+++ b/tests/test_futures_gpt_orchestrator_full.py
@@ -283,48 +283,6 @@ def test_run_closes_positions(monkeypatch):
     ]
     assert res["closed"] == ["EURUSD"]
 
-def test_run_respects_max_open_positions(monkeypatch):
-    class Ex:
-        def fetch_balance(self):
-            return {"total": {"USD": 1000}}
-
-    ex = Ex()
-    monkeypatch.setattr(orch, "load_env", lambda: None)
-    monkeypatch.setattr(orch, "get_models", lambda: (None, "MODEL"))
-    monkeypatch.setattr(orch, "ts_prefix", lambda: "ts")
-    monkeypatch.setattr(orch, "save_text", lambda *a, **k: None)
-    monkeypatch.setattr(orch, "cancel_unpositioned_limits", lambda e: None)
-    monkeypatch.setattr(orch, "remove_unmapped_limit_files", lambda e: None)
-    monkeypatch.setattr(orch, "cancel_unpositioned_stops", lambda e: None)
-    monkeypatch.setattr(orch, "env_int", lambda k, d: 10)
-    monkeypatch.setattr(orch, "get_open_position_pairs", lambda e: {f"p{i}" for i in range(11)})
-    build_called = {}
-
-    def fake_build_payload(*a, **k):
-        build_called["called"] = True
-        return {}
-
-    monkeypatch.setattr(orch, "build_payload", fake_build_payload)
-
-    class DummyDT:
-        @staticmethod
-        def now(tz=None):
-            return datetime(2024, 1, 1, 12, 0, tzinfo=timezone.utc)
-
-    monkeypatch.setattr(orch, "datetime", DummyDT)
-
-    res = orch.run(run_live=True, ex=ex)
-
-    assert not build_called.get("called")
-    assert res == {
-        "ts": "ts",
-        "live": True,
-        "capital": 1000.0,
-        "coins": [],
-        "placed": [],
-        "closed": [],
-    }
-
 
 @pytest.mark.parametrize("side,exit_side", [("buy", "sell"), ("sell", "buy")])
 def test_place_sl_tp(side, exit_side):

--- a/tests/test_futures_gpt_orchestrator_full.py
+++ b/tests/test_futures_gpt_orchestrator_full.py
@@ -3,6 +3,7 @@ import os
 import pathlib
 import sys
 import time
+from datetime import datetime, timezone
 
 import pytest
 
@@ -72,6 +73,13 @@ def test_run_sends_coins_only(monkeypatch):
     )
     monkeypatch.setattr(orch, "parse_mini_actions", lambda text: {"coins": []})
     monkeypatch.setattr(orch, "enrich_tp_qty", lambda ex, coins, capital: coins)
+
+    class DummyDT:
+        @staticmethod
+        def now(tz=None):
+            return datetime(2024, 1, 1, 12, 0, tzinfo=timezone.utc)
+
+    monkeypatch.setattr(orch, "datetime", DummyDT)
 
     res = orch.run(run_live=False, ex=DummyExchange())
 
@@ -146,6 +154,13 @@ def test_run_cancels_existing_orders(monkeypatch, tmp_path):
     monkeypatch.setattr(orch, "LIMIT_ORDER_DIR", tmp_path)
     (tmp_path / "BTCUSDT.json").write_text("{}")
 
+    class DummyDT:
+        @staticmethod
+        def now(tz=None):
+            return datetime(2024, 1, 1, 12, 0, tzinfo=timezone.utc)
+
+    monkeypatch.setattr(orch, "datetime", DummyDT)
+
     orch.run(run_live=True, ex=ex)
 
     assert ex.cancelled == [("old1", "BTC/USDT"), ("old2", "BTC/USDT")]
@@ -196,6 +211,13 @@ def test_run_skips_when_tp_missing(monkeypatch, tmp_path):
     monkeypatch.setattr(trading_utils, "calc_qty", lambda *a, **k: 1)
     monkeypatch.setattr(trading_utils, "infer_side", lambda entry, sl, tp: "buy")
 
+    class DummyDT:
+        @staticmethod
+        def now(tz=None):
+            return datetime(2024, 1, 1, 12, 0, tzinfo=timezone.utc)
+
+    monkeypatch.setattr(orch, "datetime", DummyDT)
+
     orch.run(run_live=True, ex=ex)
 
     assert len(ex.orders) == 0
@@ -240,6 +262,13 @@ def test_run_closes_positions(monkeypatch):
     monkeypatch.setattr(orch, "remove_unmapped_limit_files", lambda e: None)
     monkeypatch.setattr(orch, "cancel_unpositioned_stops", lambda e: None)
 
+    class DummyDT:
+        @staticmethod
+        def now(tz=None):
+            return datetime(2024, 1, 1, 12, 0, tzinfo=timezone.utc)
+
+    monkeypatch.setattr(orch, "datetime", DummyDT)
+
     res = orch.run(run_live=True, ex=ex)
 
     assert ex.orders == [
@@ -276,6 +305,13 @@ def test_run_respects_max_open_positions(monkeypatch):
         return {}
 
     monkeypatch.setattr(orch, "build_payload", fake_build_payload)
+
+    class DummyDT:
+        @staticmethod
+        def now(tz=None):
+            return datetime(2024, 1, 1, 12, 0, tzinfo=timezone.utc)
+
+    monkeypatch.setattr(orch, "datetime", DummyDT)
 
     res = orch.run(run_live=True, ex=ex)
 

--- a/tests/test_payload_builder.py
+++ b/tests/test_payload_builder.py
@@ -139,22 +139,17 @@ def test_coin_payload_includes_higher_timeframes(monkeypatch):
         )
 
     monkeypatch.setattr(payload_builder, "fetch_ohlcv_df", fake_fetch)
-    monkeypatch.setattr(payload_builder, "orderbook_snapshot", lambda ex, sym, depth=10: {"sp": 0.1})
-    monkeypatch.setattr(payload_builder, "funding_snapshot", lambda ex, sym: {"rate": 0.0})
-    monkeypatch.setattr(payload_builder, "open_interest_snapshot", lambda ex, sym: {"amount": 0.0})
-    monkeypatch.setattr(payload_builder, "cvd_snapshot", lambda ex, sym: {"cvd": 0.0})
-    monkeypatch.setattr(payload_builder, "liquidation_snapshot", lambda ex, sym: {"long_liq": 0.0})
+    monkeypatch.setattr(
+        payload_builder, "orderbook_snapshot", lambda ex, sym, depth=10: {"sp": 0.1}
+    )
 
-    res = payload_builder.coin_payload(None, "BTC/USDT:USDT")
+    res = payload_builder.coin_payload(None, "XAU/USD")
     assert {
         "pair",
+        "market",
         "h1",
         "h4",
         "d1",
-        "funding",
-        "oi",
-        "cvd",
-        "liquidation",
         "orderbook",
     } <= set(res.keys())
     assert res["orderbook"]["sp"] == 0.1

--- a/tests/test_positions.py
+++ b/tests/test_positions.py
@@ -5,7 +5,7 @@ class DummyExchange:
     def fetch_positions(self):
         return [
             {
-                "symbol": "BTC/USDT:USDT",
+                "symbol": "XAU/USD:USD",
                 "contracts": 1,
                 "entryPrice": 100,
                 "unrealizedPnl": 5,
@@ -24,7 +24,7 @@ def test_positions_snapshot_includes_close_position_orders():
     res = positions_snapshot(ex)
     assert len(res) == 1
     pos = res[0]
-    assert pos["pair"] == "BTCUSDT"
+    assert pos["pair"] == "XAUUSD"
     assert pos["qty"] == 1.0
     assert pos["sl"] == 90.0
     assert pos["tp"] == 110.0
@@ -34,7 +34,7 @@ class DummyExchangeNoStops:
     def fetch_positions(self):
         return [
             {
-                "symbol": "BTC/USDT:USDT",
+                "symbol": "XAU/USD:USD",
                 "contracts": 1,
                 "entryPrice": 100,
                 "unrealizedPnl": 5,
@@ -58,7 +58,7 @@ class DummyExchangeTrigger:
     def fetch_positions(self):
         return [
             {
-                "symbol": "BTC/USDT:USDT",
+                "symbol": "XAU/USD:USD",
                 "contracts": 1,
                 "entryPrice": 100,
                 "unrealizedPnl": 5,
@@ -85,7 +85,7 @@ class DummyExchangeTopTrigger:
     def fetch_positions(self):
         return [
             {
-                "symbol": "BTC/USDT:USDT",
+                "symbol": "XAU/USD:USD",
                 "contracts": 1,
                 "entryPrice": 100,
                 "unrealizedPnl": 5,
@@ -112,7 +112,7 @@ class DummyExchangeAltFields:
     def fetch_positions(self):
         return [
             {
-                "symbol": "ETH/USDT:USDT",
+                "symbol": "EUR/USD:USD",
                 "size": 2,
                 "avgPrice": "2000",
                 "unrealizedPnl": 10,
@@ -128,7 +128,7 @@ def test_positions_snapshot_handles_size_and_avgprice():
     res = positions_snapshot(ex)
     assert len(res) == 1
     pos = res[0]
-    assert pos["pair"] == "ETHUSDT"
+    assert pos["pair"] == "EURUSD"
     assert pos["qty"] == 2.0
     assert pos["entry"] == 2000.0
 
@@ -136,7 +136,7 @@ def test_positions_snapshot_handles_size_and_avgprice():
 class DummyExchangePairsAlt:
     def fetch_positions(self):
         return [
-            {"symbol": "ETH/USDT:USDT", "size": 1}
+            {"symbol": "EUR/USD:USD", "size": 1}
         ]
 
 
@@ -145,4 +145,4 @@ def test_get_open_position_pairs_supports_size():
 
     ex = DummyExchangePairsAlt()
     res = get_open_position_pairs(ex)
-    assert res == {"ETHUSDT"}
+    assert res == {"EURUSD"}

--- a/tests/test_trading_utils.py
+++ b/tests/test_trading_utils.py
@@ -9,9 +9,9 @@ import trading_utils
 
 
 def test_to_ccxt_symbol_known_quotes():
-    assert trading_utils.to_ccxt_symbol("BTCUSDT") == "BTC/USDT"
-    assert trading_utils.to_ccxt_symbol("ETHBTC") == "ETH/BTC"
-    assert trading_utils.to_ccxt_symbol("LTCBUSD") == "LTC/BUSD"
+    assert trading_utils.to_ccxt_symbol("XAUUSD") == "XAU/USD"
+    assert trading_utils.to_ccxt_symbol("EURJPY") == "EUR/JPY"
+    assert trading_utils.to_ccxt_symbol("GBPUSD") == "GBP/USD"
 
 
 def test_to_ccxt_symbol_with_exchange_markets():
@@ -22,18 +22,18 @@ def test_to_ccxt_symbol_with_exchange_markets():
 def test_parse_mini_actions_coins_only():
     text = (
         "{"
-        '"coins":[{"pair":"BTCUSDT","entry":1,"sl":0.9,"tp":1.05,"risk":0.1}],'
-        '"close":["ETHUSDT"]}'
+        '"coins":[{"pair":"XAUUSD","entry":1,"sl":0.9,"tp":1.05,"risk":0.1}],'
+        '"close":["EURUSD"]}'
     )
     res = trading_utils.parse_mini_actions(text)
-    assert res["coins"] and res["coins"][0]["pair"] == "BTCUSDT"
+    assert res["coins"] and res["coins"][0]["pair"] == "XAUUSD"
     assert res["coins"][0]["tp"] == 1.05
     assert res["coins"][0]["risk"] == 0.1
-    assert res["close"] == ["ETHUSDT"]
+    assert res["close"] == ["EURUSD"]
 
 
 def test_parse_mini_actions_requires_tp():
-    text = '{"coins":[{"pair":"BTCUSDT","entry":1,"sl":0.9,"tp1":1.05}]}'
+    text = '{"coins":[{"pair":"XAUUSD","entry":1,"sl":0.9,"tp1":1.05}]}'
     res = trading_utils.parse_mini_actions(text)
     assert res["coins"] == []
 
@@ -51,7 +51,7 @@ def test_enrich_tp_qty_keeps_tp(monkeypatch):
     monkeypatch.setattr(trading_utils, "infer_side", lambda entry, sl, tp: "buy")
     acts = [
         {
-            "pair": "BTCUSDT",
+            "pair": "XAUUSD",
             "entry": 100,
             "sl": 90,
             "tp": 110,
@@ -75,7 +75,7 @@ def test_enrich_tp_qty_uses_env_default_risk(monkeypatch):
     monkeypatch.setattr(trading_utils, "DEFAULT_RISK_FRAC", 0.02)
     acts = [
         {
-            "pair": "BTCUSDT",
+            "pair": "XAUUSD",
             "entry": 100,
             "sl": 90,
             "tp": 110,
@@ -96,7 +96,7 @@ def test_enrich_tp_qty_skips_when_tp_missing(monkeypatch):
         lambda capital, rf, entry, sl, step, max_lev, contract: 1,
     )
     monkeypatch.setattr(trading_utils, "infer_side", lambda entry, sl, tp: "buy")
-    acts = [{"pair": "BTCUSDT", "entry": 100, "sl": 90}]
+    acts = [{"pair": "XAUUSD", "entry": 100, "sl": 90}]
     res = trading_utils.enrich_tp_qty(ex, acts, capital=1000)
     assert res == []
 

--- a/trading_utils.py
+++ b/trading_utils.py
@@ -80,13 +80,16 @@ def parse_mini_actions(text: str) -> Dict[str, Any]:
 
 
 KNOWN_QUOTES: Iterable[str] = (
-    "USDT",
-    "BUSD",
-    "USDC",
     "USD",
-    "BTC",
-    "ETH",
-    "BNB",
+    "EUR",
+    "JPY",
+    "GBP",
+    "AUD",
+    "CAD",
+    "CHF",
+    "NZD",
+    "XAU",
+    "XAG",
 )
 
 


### PR DESCRIPTION
## Summary
- Switch exchange helpers to OANDA and strip crypto-specific logic
- Extend payload with forex details and DXY index data
- Restrict live runs to London–New York session and accept USD balances

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bb00ff21148323aee5d54856069a9b